### PR TITLE
Fix missing extensions

### DIFF
--- a/transkribus_fixer/cli.py
+++ b/transkribus_fixer/cli.py
@@ -8,21 +8,21 @@ FIXERS = [func[4:] for func in dir(TranskribusFixer)
           if callable(getattr(TranskribusFixer, func)) and func.startswith('fix_')]
 FIXERDOCS = [func + ': ' + getattr(TranskribusFixer, 'fix_' + func).__doc__ for func in FIXERS]
 FIXERS.append('namespace')
+FIXERDOCS.append('namespace: Also convert PAGE namespace version from 2013 to 2019.')
 
 
 @command(context_settings={'help_option_names': ['-h', '--help']})
 @option('-f', '--fixes', help="Fixes to apply. Repeatable [default: all].\n\n" + "\n\n".join(FIXERDOCS),
         default=FIXERS, type=Choice(FIXERS), multiple=True)
+@option('-I', '--prefer-imgurl', help="use TranskribusMetadata/@imgUrl for @imageFilename if available", is_flag=True)
 @option('-V', '--validate', help="Validate output against schema.", is_flag=True)
 @argument('input-file', type=File('r'), nargs=1)
 @argument('output-file', default='-', type=File('w'), nargs=1)
-def cli(fixes, validate, input_file, output_file):
+def cli(fixes, prefer_imgurl, validate, input_file, output_file):
     """
     Transform (Transkribus PAGE) INPUT_FILE to (PRImA PAGE) OUTPUT_FILE under the chosen fixes.
-
-    Also convert PAGE namespace version from 2013 to 2019.
     """
-    fixer = TranskribusFixer(ET.parse(input_file))
+    fixer = TranskribusFixer(ET.parse(input_file), prefer_imgurl)
     for fix in [f for f in fixes if f != 'namespace']:
         getattr(fixer, f'fix_{fix}')()
     as_str = fixer.tostring()

--- a/transkribus_fixer/fixer.py
+++ b/transkribus_fixer/fixer.py
@@ -9,20 +9,26 @@ class TranskribusFixer():
     Translates Transkribus variant of PAGE to standard-conformant PAGE
     """
 
-    def __init__(self, tree):
+    def __init__(self, tree, prefer_imgurl=False):
         self.tree = tree
+        self.prefer_imgurl = prefer_imgurl
 
     def fix_metadata(self):
         """Remove any Metadata/TranskribusMetadata"""
-        el_metadata = self.tree.xpath('//*[local-name()="TranskribusMetadata"]')
-        if el_metadata:
-            el_metadata[0].getparent().remove(el_metadata[0])
+        el_page = self.tree.find('{*}Page')
+        el_metadata = self.tree.find('{*}Metadata')
+        if el_metadata is not None:
+            el_metadata = el_metadata.find('{*}TranskribusMetadata')
+        if el_metadata is not None:
+            if self.prefer_imgurl and 'imgUrl' in el_metadata.attrib:
+                el_page.attrib['imageFilename'] = el_metadata.attrib['imgUrl']
+            el_metadata.getparent().remove(el_metadata)
 
     def fix_reading_order(self):
         """Convert ???"""
         ro = self.tree.xpath('//*[local-name()="ReadingOrder"]/*[local-name()="OrderedGroup"]')[0]
         relations = self.tree.xpath('//*[local-name()="Relations"]')
-        if not relations:
+        if not len(relations):
             return
         relations = relations[0]
         for relation in relations.xpath('*[local-name()="Relation"][@type="link"]'):


### PR DESCRIPTION
Fixes #1, #2, #3 (but we could do more here), #4, #6 and #8.

Here's the current output of `-h`:

```
Usage: transkribus-fixer [OPTIONS] INPUT_FILE [OUTPUT_FILE]

  Transform (Transkribus PAGE) INPUT_FILE to (PRImA PAGE) OUTPUT_FILE under
  the chosen fixes.

Options:
  -f, --fixes [image_transform|metadata|reading_order|table|tag_property_link|textequiv|namespace]
                                  Fixes to apply. Repeatable [default: all].
                                  
                                  image_transform: Convert
                                  Page/@image(Rotation|Translation|Scaling) to
                                  Labels
                                  
                                  metadata: Remove any
                                  Metadata/TranskribusMetadata
                                  
                                  reading_order: Convert ???
                                  
                                  table: Convert each TableRegion/TableCell
                                  into a TableRegion/TextRegion, writing
                                  row/col index/span as new TableCellRole
                                  accordingly
                                  
                                  tag_property_link: Remove Tag, Property and
                                  Link elements whereever they appear
                                  
                                  textequiv: Convert any
                                  //TextEquiv/UnicodeAlternative into
                                  additional ../TextEquiv/Unicode
                                  
                                  namespace: Also convert PAGE namespace
                                  version from 2013 to 2019.

  -I, --prefer-imgurl             use TranskribusMetadata/@imgUrl for
                                  @imageFilename if available

  -V, --validate                  Validate output against schema.
  -h, --help                      Show this message and exit.
```