### PR TITLE
Fixes #1, #2, #3, #4, #6 and #8

### DIFF
--- a/transkribus_fixer/cli.py
+++ b/transkribus_fixer/cli.py
@@ -1,26 +1,43 @@
-from click import command, Choice, argument, option
+from pkg_resources import resource_filename
+from click import command, Choice, File, argument, option
 from lxml import etree as ET
 
 from .fixer import TranskribusFixer, NS
 
-@command()
-@option('-f', '--fixes', help="Fixes to apply. Repeatable", type=Choice(['reading_order', 'table', 'metadata', 'namespace']), multiple=True)
-@argument('input-file', nargs=1)
-@argument('output-file', nargs=1)
-def cli(fixes, input_file, output_file):
-    """
-    Apply the fixes to INPUT_FILE.
+FIXERS = [func[4:] for func in dir(TranskribusFixer)
+          if callable(getattr(TranskribusFixer, func)) and func.startswith('fix_')]
+FIXERDOCS = [func + ': ' + getattr(TranskribusFixer, 'fix_' + func).__doc__ for func in FIXERS]
+FIXERS.append('namespace')
+FIXERDOCS.append('namespace: Also convert PAGE namespace version from 2013 to 2019.')
 
-    Also converts PAGE2013 to PAGE2019 when writing to OUTPUT_FILE.
+
+@command(context_settings={'help_option_names': ['-h', '--help']})
+@option('-f', '--fixes', help="Fixes to apply. Repeatable [default: all].\n\n" + "\n\n".join(FIXERDOCS),
+        default=FIXERS, type=Choice(FIXERS), multiple=True)
+@option('-I', '--prefer-imgurl', help="use TranskribusMetadata/@imgUrl for @imageFilename if available", is_flag=True)
+@option('-V', '--validate', help="Validate output against schema.", is_flag=True)
+@argument('input-file', type=File('r'), nargs=1)
+@argument('output-file', default='-', type=File('w'), nargs=1)
+def cli(fixes, prefer_imgurl, validate, input_file, output_file):
     """
-    fixer = TranskribusFixer(ET.parse(input_file))
+    Transform (Transkribus PAGE) INPUT_FILE to (PRImA PAGE) OUTPUT_FILE under the chosen fixes.
+    """
+    fixer = TranskribusFixer(ET.parse(input_file), prefer_imgurl)
     for fix in [f for f in fixes if f != 'namespace']:
         getattr(fixer, f'fix_{fix}')()
-    with open('/dev/stdout' if output_file == '-' else output_file, 'w') as f:
-        as_str = fixer.tostring()
-        if 'namespace' in fixes:
-            as_str = as_str.replace(NS['p2013'], NS['p2019'])
-        f.write(as_str)
+    as_str = fixer.tostring()
+    if 'namespace' in fixes:
+        as_str = as_str.replace(NS['p2013'], NS['p2019'])
+    if validate:
+        if 'namespace' not in fixes and fixer.tree.getroot().tag == "{%s}PcGts" % NS['p2013']:
+            schema = resource_filename(__name__, 'page2013.xsd')
+        else:
+            schema = resource_filename(__name__, 'page2019.xsd')
+        schema = ET.parse(schema)
+        schema = ET.XMLSchema(schema)
+        #schema.assertValid(fixer.tree) # may need namespace fixer
+        schema.assertValid(ET.fromstring(as_str.encode('utf-8')))
+    output_file.write(as_str)
 
 if __name__ == "__main__":
     cli()

--- a/transkribus_fixer/fixer.py
+++ b/transkribus_fixer/fixer.py
@@ -9,18 +9,26 @@ class TranskribusFixer():
     Translates Transkribus variant of PAGE to standard-conformant PAGE
     """
 
-    def __init__(self, tree):
+    def __init__(self, tree, prefer_imgurl=False):
         self.tree = tree
+        self.prefer_imgurl = prefer_imgurl
 
     def fix_metadata(self):
-        el_metadata = self.tree.xpath('//*[local-name()="TranskribusMetadata"]')
-        if el_metadata:
-            el_metadata[0].getparent().remove(el_metadata[0])
+        """Remove any Metadata/TranskribusMetadata"""
+        el_page = self.tree.find('{*}Page')
+        el_metadata = self.tree.find('{*}Metadata')
+        if el_metadata is not None:
+            el_metadata = el_metadata.find('{*}TranskribusMetadata')
+        if el_metadata is not None:
+            if self.prefer_imgurl and 'imgUrl' in el_metadata.attrib:
+                el_page.attrib['imageFilename'] = el_metadata.attrib['imgUrl']
+            el_metadata.getparent().remove(el_metadata)
 
     def fix_reading_order(self):
+        """Convert ???"""
         ro = self.tree.xpath('//*[local-name()="ReadingOrder"]/*[local-name()="OrderedGroup"]')[0]
         relations = self.tree.xpath('//*[local-name()="Relations"]')
-        if not relations:
+        if not len(relations):
             return
         relations = relations[0]
         for relation in relations.xpath('*[local-name()="Relation"][@type="link"]'):
@@ -37,22 +45,92 @@ class TranskribusFixer():
             relations.getparent().remove(relations)
 
     def fix_table(self):
+        """Convert each TableRegion/TableCell into a TableRegion/TextRegion, writing row/col index/span as new TableCellRole accordingly"""
         for el_table in self.tree.xpath('//*[local-name()="TableRegion"]'):
             for el_cell in el_table.xpath('*[local-name()="TableCell"]'):
                 el_table.remove(el_cell)
                 el_region = ET.SubElement(el_table, '{%s}TextRegion' % NS2013)
-                el_region.insert(0, el_cell.xpath('*[local-name()="Coords"]')[0])
-                el_roles = ET.SubElement(el_region, '{%s}Roles' % NS2013)
+                for att in ['id', 'custom', 'comments', 'continuation', 'production',
+                            'orientation', 'type', 'leading', 'indented', 'align',
+                            'readingDirection', 'readingOrientation', 'textLineOrder',
+                            'primaryLanguage', ',secondaryLanguage',
+                            'primaryScript', 'secondaryScript']:
+                    if att in el_cell.attrib:
+                        el_region.set(att, el_cell.get(att))
+                for node in el_cell.iterchildren("{*}AlternativeImage", "{*}Coords",
+                                                 "{*}UserDefined", "{*}Labels",
+                                                 "{*}Roles"):
+                    el_region.append(node)
+                el_roles = el_region.find('{*}Roles')
+                if el_roles is None:
+                    el_roles = ET.SubElement(el_region, '{%s}Roles' % NS2013)
+                # NS2013 does not have TableCellRole, so we implicitly rely on the namespace fixer here
                 el_tablecellrole = ET.SubElement(el_roles, '{%s}TableCellRole' % NS2013)
                 el_tablecellrole.set('rowIndex', el_cell.get('row'))
                 el_tablecellrole.set('columnIndex', el_cell.get('col'))
                 el_tablecellrole.set('rowSpan', el_cell.get('rowSpan', '1'))
                 el_tablecellrole.set('colSpan', el_cell.get('colSpan', '1'))
-                for att in ['orientation', 'id']:
-                    if att in el_cell.attrib:
-                        el_region.set(att, el_cell.get(att))
-                for el_textline in el_cell.xpath('*[local-name()="TextLine"]'):
-                    el_region.append(el_textline)
+                el_tablecellrole.set('header', el_cell.get('label', "false"))
+                for node in el_cell.iterchildren():
+                    if any(node.tag.endswith(suf)
+                           for suf in ['Region', 'TextLine', 'TextEquiv', 'TextStyle']):
+                        el_region.append(node)
+
+    def fix_textequiv(self):
+        """Convert any //TextEquiv/UnicodeAlternative into additional ../TextEquiv/Unicode"""
+        for el_te in self.tree.xpath('//*[local-name()="TextEquiv"]'):
+            for el_uni in el_te.xpath('//*[local-name()="UnicodeAlternative"]'):
+                el_te.remove(el_uni)
+                el_tenew = ET.SubElement(el_te.getparent(), '{%s}TextEquiv' % NS2013)
+                el_tenewuni = ET.SubElement(el_tenew, '{%s}Unicode' % NS2013)
+                el_tenewuni.text = el_uni.text
+
+    def fix_image_transform(self):
+        """Convert Page/@image(Rotation|Translation|Scaling) to Labels"""
+        el_page = self.tree.find('{*}Page')
+        el_labels = el_page.find('{*}Labels')
+        def new_label(typ, val):
+            nonlocal el_labels
+            if el_labels is None:
+                el_labels = ET.Element('{%s}Labels' % NS2013)
+                el_labels.set('externalModel', 'TranskribusImageTransform')
+                # find position to insert (labels go right before regions)
+                regions = el_page.xpath('*[contains(local-name(),"Region")]')
+                if len(regions):
+                    regions[0].addprevious(el_labels)
+                else:
+                    el_page.append(el_labels)
+            el_label = ET.SubElement(el_labels, '{%s}Label' % NS2013)
+            el_label.set('type', typ)
+            el_label.set('value', val)
+        for label in ['imageRotation',
+                      'imageTranslationX',
+                      'imageTranslationY',
+                      'imageScalingX',
+                      'imageScalingY']:
+            if label in el_page.attrib:
+                new_label(label, el_page.attrib.pop(label))
+
+    def fix_tag_property_link(self):
+        """Remove Tag, Property and Link elements whereever they appear"""
+        # all known under PageType, RegionType, TextLineType, WordType, GlyphType
+        # Tag known under TextEquivType
+        # Property known under TranskribusMetadataType
+        # ...but we might as well search everywhere
+        # FIXME: convert these to Labels and Relations
+        for node in self.tree.iter():
+            tag = node.find('{*}Tag')
+            if tag is not None:
+                node.remove(tag)
+            prop = node.find('{*}Property')
+            if prop is not None:
+                node.remove(prop)
+            link = node.find('{*}Link')
+            if link is not None:
+                node.remove(link)
 
     def tostring(self):
-        return ET.tostring(self.tree, pretty_print=True, encoding='utf-8').decode('utf-8')
+        return ET.tostring(self.tree,
+                           pretty_print=True,
+                           xml_declaration=True,
+                           encoding='utf-8').decode('utf-8')

--- a/transkribus_fixer/page2013.xsd
+++ b/transkribus_fixer/page2013.xsd
@@ -1,0 +1,1440 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<schema targetNamespace="http://schema.primaresearch.org/PAGE/gts/pagecontent/2013-07-15"
+	elementFormDefault="qualified" xmlns="http://www.w3.org/2001/XMLSchema"
+	xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2013-07-15">
+
+    <element name="PcGts" type="pc:PcGtsType">
+		<annotation>
+			<documentation>Page Content - Ground Truth and Storage</documentation>
+		</annotation></element>
+	<complexType name="PcGtsType">
+		<sequence>
+			<element name="Metadata" type="pc:MetadataType"></element>
+			<element name="Page" type="pc:PageType"></element>
+		</sequence>
+		<attribute name="pcGtsId" type="ID" use="optional"></attribute>
+	</complexType>
+	<complexType name="MetadataType">
+		<sequence>
+			<element name="Creator" type="string"></element>
+			<element name="Created" type="dateTime">
+				<annotation>
+					<documentation>The timestamp has to be in UTC (Coordinated Universal Time) and not local time.</documentation></annotation></element>
+			<element name="LastChange" type="dateTime">
+				<annotation>
+					<documentation>The timestamp has to be in UTC (Coordinated Universal Time) and not local time.</documentation></annotation></element>
+			<element name="Comments" type="string" minOccurs="0"
+				maxOccurs="1"></element>
+		</sequence>
+	</complexType>
+	<complexType name="PageType">
+		<sequence>
+			<element name="AlternativeImage"
+				type="pc:AlternativeImageType" minOccurs="0"
+				maxOccurs="unbounded">
+				<annotation>
+					<documentation>
+						Alternative document page images (e.g.
+						black-and-white)
+					</documentation>
+				</annotation>
+			</element>
+			<element name="Border" type="pc:BorderType" minOccurs="0"
+				maxOccurs="1">
+			</element>
+			<element name="PrintSpace" type="pc:PrintSpaceType"
+				minOccurs="0" maxOccurs="1">
+			</element>
+			<element name="ReadingOrder" type="pc:ReadingOrderType"
+				minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation></documentation>
+				</annotation>
+			</element>
+			<element name="Layers" type="pc:LayersType" minOccurs="0"
+				maxOccurs="1">
+				<annotation>
+					<documentation>Unassigned regions are considered to be in the (virtual) default layer which is to be treated as below any other layers.</documentation>
+				</annotation>
+			</element>
+            <element name="Relations" type="pc:RelationsType" minOccurs="0">
+				</element>
+            <choice minOccurs="0" maxOccurs="unbounded">
+				<element name="TextRegion" type="pc:TextRegionType"></element>
+				<element name="ImageRegion" type="pc:ImageRegionType">
+				</element>
+				<element name="LineDrawingRegion"
+					type="pc:LineDrawingRegionType">
+				</element>
+				<element name="GraphicRegion"
+					type="pc:GraphicRegionType">
+				</element>
+				<element name="TableRegion" type="pc:TableRegionType">
+				</element>
+				<element name="ChartRegion" type="pc:ChartRegionType">
+				</element>
+				<element name="SeparatorRegion"
+					type="pc:SeparatorRegionType">
+				</element>
+				<element name="MathsRegion" type="pc:MathsRegionType">
+				</element>
+				<element name="ChemRegion" type="pc:ChemRegionType"></element>
+				<element name="MusicRegion" type="pc:MusicRegionType"></element>
+                <element name="AdvertRegion" type="pc:AdvertRegionType">
+				</element>
+                <element name="NoiseRegion" type="pc:NoiseRegionType">
+				</element>
+				<element name="UnknownRegion"
+					type="pc:UnknownRegionType">
+				</element>
+			</choice>
+
+		</sequence>
+		<attribute name="imageFilename" type="string" use="required"></attribute>
+		<attribute name="imageWidth" type="int" use="required"></attribute>
+		<attribute name="imageHeight" type="int" use="required"></attribute>
+		<attribute name="custom" type="string">
+			<annotation>
+				<documentation>For generic use</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="type" type="pc:PageTypeSimpleType">
+            <annotation>
+            	<documentation>Page type</documentation>
+            </annotation>
+		</attribute>
+	</complexType>
+	<complexType name="TextRegionType">
+		<annotation>
+			<documentation>
+				Pure text is represented as a text region. This includes
+				drop capitals, but practically ornate text may be
+				considered as a graphic.
+			</documentation>
+		</annotation>
+	    <complexContent>
+	      <extension base="pc:RegionType">
+			<sequence>
+				<element name="TextLine" type="pc:TextLineType"
+					minOccurs="0" maxOccurs="unbounded">
+				</element>
+				<element name="TextEquiv" type="pc:TextEquivType"
+					minOccurs="0" maxOccurs="1">
+				</element>
+				<element name="TextStyle" type="pc:TextStyleType"
+					minOccurs="0" maxOccurs="1">
+				</element>
+			</sequence>
+			<attribute name="orientation" type="float" use="optional">
+				<annotation>
+					<documentation>The angle the rectangle encapsulating a region has to be rotated in clockwise direction in order to correct the present skew (negative values indicate anti-clockwise rotation).
+Range: -179.999,180</documentation>
+				</annotation>
+			</attribute>
+			<attribute name="type" type="pc:TextTypeSimpleType"
+				use="optional">
+				<annotation>
+					<documentation>
+						The nature of the text in the region
+					</documentation>
+				</annotation>
+			</attribute>
+			<attribute name="leading" type="int" use="optional">
+				<annotation>
+					<documentation>
+						The degree of space in points between the lines of
+						text (line spacing)
+					</documentation>
+				</annotation>
+			</attribute>
+			<attribute name="readingDirection"
+				type="pc:ReadingDirectionSimpleType" use="optional">
+				<annotation>
+					<documentation>
+						The direction in which text in a region should be
+						read (within lines)
+					</documentation>
+				</annotation>
+			</attribute>
+			<attribute name="readingOrientation" type="float"
+				use="optional">
+				<annotation>
+					<documentation>The angle the baseline of text withing a region has to be rotated (relative to the rectangle encapsulating the region) in clockwise direction in order to correct the present skew (negative values indicate anti-clockwise rotation).
+Range: -179.999,180</documentation>
+				</annotation>
+			</attribute>
+			<attribute name="indented" type="boolean" use="optional">
+				<annotation>
+					<documentation>
+						Defines whether a region of text is indented or not
+					</documentation>
+				</annotation>
+			</attribute>
+			<attribute name="align" type="pc:AlignSimpleType">
+				<annotation>
+					<documentation>Text align</documentation>
+				</annotation>
+			</attribute>
+			<attribute name="primaryLanguage" type="pc:LanguageSimpleType"
+				use="optional">
+				<annotation>
+					<documentation>
+						The primary language used in the region
+					</documentation>
+				</annotation>
+			</attribute>
+			<attribute name="secondaryLanguage" type="pc:LanguageSimpleType"
+				use="optional">
+				<annotation>
+					<documentation>
+						The secondary language used in the region
+					</documentation>
+				</annotation>
+			</attribute>
+			<attribute name="primaryScript" type="pc:ScriptSimpleType"
+				use="optional">
+				<annotation>
+					<documentation>
+						The primary script used in the region
+					</documentation>
+				</annotation>
+			</attribute>
+			<attribute name="secondaryScript" type="pc:ScriptSimpleType"
+				use="optional">
+				<annotation>
+					<documentation>
+						The secondary script used in the region
+					</documentation>
+				</annotation>
+			</attribute>
+			<attribute name="production" type="pc:ProductionSimpleType"></attribute>
+	      </extension>
+	    </complexContent>
+	</complexType>
+	<complexType name="CoordsType">
+		<attribute name="points" use="required" type="pc:PointsType">
+            <annotation>
+            	<documentation>Point list with format "x1,y1 x2,y2 ..."</documentation>
+            </annotation>
+		</attribute>
+	</complexType>
+	<complexType name="TextLineType">
+		<sequence>
+			<element name="Coords" type="pc:CoordsType"></element>
+			<element name="Baseline" type="pc:BaselineType"
+				minOccurs="0">
+				<annotation>
+					<documentation>
+						Multiple connected points that mark the baseline
+						of the glyphs
+					</documentation>
+				</annotation>
+			</element>
+			<element name="Word" type="pc:WordType" minOccurs="0"
+				maxOccurs="unbounded">
+			</element>
+			<element name="TextEquiv" type="pc:TextEquivType"
+				minOccurs="0" maxOccurs="1">
+			</element>
+			<element name="TextStyle" type="pc:TextStyleType" minOccurs="0"></element>
+		</sequence>
+		<attribute name="id" type="ID" use="required"></attribute>
+		<attribute name="primaryLanguage"
+			type="pc:LanguageSimpleType">
+			<annotation>
+				<documentation>
+					Overrides primaryLanguage attribute of parent text
+					region
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="production" type="pc:ProductionSimpleType">
+			<annotation>
+				<documentation>
+					Overrides the production attribute of the parent
+					text region
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="custom" type="string">
+			<annotation>
+				<documentation>For generic use</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="comments" type="string"></attribute>
+	</complexType>
+	<complexType name="WordType">
+		<sequence>
+			<element name="Coords" type="pc:CoordsType"></element>
+			<element name="Glyph" type="pc:GlyphType" minOccurs="0"
+				maxOccurs="unbounded">
+			</element>
+			<element name="TextEquiv" type="pc:TextEquivType"
+				minOccurs="0" maxOccurs="1">
+			</element>
+			<element name="TextStyle" type="pc:TextStyleType" minOccurs="0"></element>
+		</sequence>
+		<attribute name="id" type="ID" use="required"></attribute>
+		<attribute name="language" type="pc:LanguageSimpleType">
+			<annotation>
+				<documentation>
+					Overrides primaryLanguage attribute of parent line
+					and/or text region
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="production" type="pc:ProductionSimpleType">
+			<annotation>
+				<documentation>
+					Overrides the production attribute of the parent
+					text line and/or text region.
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="custom" type="string">
+			<annotation>
+				<documentation>For generic use</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="comments" type="string"></attribute>
+	</complexType>
+	<complexType name="GlyphType">
+		<sequence>
+			<element name="Coords" type="pc:CoordsType"></element>
+			<element name="TextEquiv" type="pc:TextEquivType"
+				minOccurs="0" maxOccurs="1">
+			</element>
+			<element name="TextStyle" type="pc:TextStyleType" minOccurs="0"></element>
+		</sequence>
+		<attribute name="id" type="ID" use="required"></attribute>
+		<attribute name="ligature" use="optional" type="boolean">
+		</attribute>
+		<attribute name="symbol" use="optional" type="boolean">
+		</attribute>
+		<attribute name="production" type="pc:ProductionSimpleType">
+			<annotation>
+				<documentation>
+					Overrides the production attribute of the parent
+					word / text line / text region.
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="custom" type="string">
+			<annotation>
+				<documentation>For generic use</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="comments" type="string"></attribute>
+	</complexType>
+	<complexType name="TextEquivType">
+		<sequence>
+			<element name="PlainText" type="string" minOccurs="0">
+				<annotation>
+					<documentation>
+						Text in a "simple" form (ASCII or extended ASCII
+						as mostly used for typing). I.e. no use of
+						special characters for ligatures (should be
+						stored as two separate characters) etc.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="Unicode" type="string">
+				<annotation>
+					<documentation>
+						Correct encoding of the original, always using
+						the corresponding Unicode code point. I.e.
+						ligatures have to be represented as one
+						character etc.
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+		<attribute name="conf">
+            <annotation>
+            	<documentation>OCR confidence value (between 0 and 1)</documentation>
+            </annotation>
+            <simpleType>
+            	<restriction base="float">
+            		<minInclusive value="0"></minInclusive>
+            		<maxInclusive value="1"></maxInclusive>
+            	</restriction>
+            </simpleType>
+		</attribute>
+	</complexType>
+	<complexType name="ImageRegionType">
+		<annotation>
+			<documentation>
+				An image is considered to be more intricate and complex
+				than a graphic. These can be photos or drawings.
+			</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="pc:RegionType">
+				<attribute name="orientation" type="float"
+					use="optional">
+					<annotation>
+						<documentation>The angle the rectangle encapsulating a region has to be rotated in clockwise direction in order to correct the present skew (negative values indicate anti-clockwise rotation).
+Range: -179.999,180</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="colourDepth"
+					type="pc:ColourDepthSimpleType" use="optional">
+					<annotation>
+						<documentation>
+							The colour bit depth required for the region
+						</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="bgColour" type="pc:ColourSimpleType"
+					use="optional">
+					<annotation>
+						<documentation>
+							The background colour of the region
+						</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="embText" type="boolean"
+					use="optional">
+					<annotation>
+						<documentation>
+							Specifies whether the region also contains
+							text
+						</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="LineDrawingRegionType">
+		<annotation>
+			<documentation>
+				A line drawing is a single colour illustration without
+				solid areas.
+			</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="pc:RegionType">
+				<attribute name="orientation" type="float"
+					use="optional">
+					<annotation>
+						<documentation>The angle the rectangle encapsulating a region has to be rotated in clockwise direction in order to correct the present skew (negative values indicate anti-clockwise rotation).
+Range: -179.999,180</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="penColour" type="pc:ColourSimpleType"
+					use="optional">
+					<annotation>
+						<documentation>
+							The pen (foreground) colour of the region
+						</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="bgColour" type="pc:ColourSimpleType"
+					use="optional">
+					<annotation>
+						<documentation>
+							The background colour of the region
+						</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="embText" type="boolean"
+					use="optional">
+					<annotation>
+						<documentation>
+							Specifies whether the region also contains
+							text
+						</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="GraphicRegionType">
+		<annotation>
+			<documentation>
+				Regions containing simple graphics, such as a company
+				logo, should be marked as graphic regions.
+			</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="pc:RegionType">
+				<attribute name="orientation" type="float"
+					use="optional">
+					<annotation>
+						<documentation>The angle the rectangle encapsulating a region has to be rotated in clockwise direction in order to correct the present skew (negative values indicate anti-clockwise rotation).
+Range: -179.999,180</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="type" use="optional"
+					type="pc:GraphicsTypeSimpleType">
+					<annotation>
+						<documentation>
+							The type of graphic in the region
+						</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="numColours" type="int"
+					use="optional">
+					<annotation>
+						<documentation>
+							An approximation of the number of colours
+							used in the region
+						</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="embText" type="boolean"
+					use="optional">
+					<annotation>
+						<documentation>
+							Specifies whether the region also contains
+							text.
+						</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="TableRegionType">
+		<annotation>
+			<documentation>
+				Tabular data in any form is represented with a table
+				region. Rows and columns may or may not have separator
+				lines; these lines are not separator regions.
+			</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="pc:RegionType">
+				<attribute name="orientation" type="float"
+					use="optional">
+					<annotation>
+						<documentation>The angle the rectangle encapsulating a region has to be rotated in clockwise direction in order to correct the present skew (negative values indicate anti-clockwise rotation).
+Range: -179.999,180</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="rows" type="int" use="optional">
+					<annotation>
+						<documentation>
+							The number of rows present in the table
+						</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="columns" type="int" use="optional">
+					<annotation>
+						<documentation>
+							The number of columns present in the table
+						</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="lineColour" type="pc:ColourSimpleType"
+					use="optional">
+					<annotation>
+						<documentation>
+							The colour of the lines used in the region
+						</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="bgColour" type="pc:ColourSimpleType"
+					use="optional">
+					<annotation>
+						<documentation>
+							The background colour of the region
+						</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="lineSeparators" type="boolean"
+					use="optional">
+					<annotation>
+						<documentation>
+							Specifies the presence of line separators
+						</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="embText" type="boolean"
+					use="optional">
+					<annotation>
+						<documentation>
+							Specifies whether the region also contains
+							text
+						</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="ChartRegionType">
+		<annotation>
+			<documentation>
+				Regions containing charts or graphs of any type, should
+				be marked as chart regions.
+			</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="pc:RegionType">
+				<attribute name="orientation" type="float"
+					use="optional">
+					<annotation>
+						<documentation>The angle the rectangle encapsulating a region has to be rotated in clockwise direction in order to correct the present skew (negative values indicate anti-clockwise rotation).
+Range: -179.999,180</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="type" use="optional"
+					type="pc:ChartTypeSimpleType">
+					<annotation>
+						<documentation>
+							The type of chart in the region
+						</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="numColours" type="int"
+					use="optional">
+					<annotation>
+						<documentation>
+							An approximation of the number of colours
+							used in the region
+						</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="bgColour" type="pc:ColourSimpleType"
+					use="optional">
+					<annotation>
+						<documentation>
+							The background colour of the region
+						</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="embText" type="boolean"
+					use="optional">
+					<annotation>
+						<documentation>
+							Specifies whether the region also contains
+							text
+						</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="SeparatorRegionType">
+		<annotation>
+			<documentation>
+				Separators are lines that lie between columns and
+				paragraphs and can be used to logically separate
+				different articles from each other.
+			</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="pc:RegionType">
+				<attribute name="orientation" type="float"
+					use="optional">
+					<annotation>
+						<documentation>The angle the rectangle encapsulating a region has to be rotated in clockwise direction in order to correct the present skew (negative values indicate anti-clockwise rotation).
+Range: -179.999,180</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="colour" type="pc:ColourSimpleType"
+					use="optional">
+					<annotation>
+						<documentation>
+							The colour of the separator
+						</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="MathsRegionType">
+		<annotation>
+			<documentation>
+				Regions containing equations and mathematical symbols
+				should be marked as maths regions.
+			</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="pc:RegionType">
+				<attribute name="orientation" type="float"
+					use="optional">
+					<annotation>
+						<documentation>The angle the rectangle encapsulating a region has to be rotated in clockwise direction in order to correct the present skew (negative values indicate anti-clockwise rotation).
+Range: -179.999,180</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="bgColour" type="pc:ColourSimpleType"
+					use="optional">
+					<annotation>
+						<documentation>
+							The background colour of the region
+						</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="ChemRegionType">
+		<annotation>
+			<documentation>
+				Regions containing chemical formulas.
+			</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="pc:RegionType">
+				<attribute name="orientation" type="float"
+					use="optional">
+					<annotation>
+						<documentation>
+							The angle the rectangle encapsulating a
+							region has to be rotated in clockwise
+							direction in order to correct the present
+							skew (negative values indicate
+							anti-clockwise rotation). Range:
+							-179.999,180
+						</documentation>
+					</annotation>
+				</attribute>
+
+				<attribute name="bgColour" type="pc:ColourSimpleType"
+					use="optional">
+					<annotation>
+						<documentation>
+							The background colour of the region
+						</documentation>
+					</annotation>
+				</attribute>
+
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="MusicRegionType">
+		<annotation>
+			<documentation>
+				Regions containing musical notations.
+			</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="pc:RegionType">
+				<attribute name="orientation" type="float"
+					use="optional">
+					<annotation>
+						<documentation>The angle the rectangle encapsulating a region has to be rotated in clockwise direction in order to correct the present skew (negative values indicate anti-clockwise rotation).
+Range: -179.999,180</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="bgColour" type="pc:ColourSimpleType"
+					use="optional">
+					<annotation>
+						<documentation>
+							The background colour of the region
+						</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="AdvertRegionType">
+		<annotation>
+			<documentation>
+				Regions containing advertisements.
+			</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="pc:RegionType">
+				<attribute name="orientation" type="float"
+					use="optional">
+					<annotation>
+						<documentation>The angle the rectangle encapsulating a region has to be rotated in clockwise direction in order to correct the present skew (negative values indicate anti-clockwise rotation).
+Range: -179.999,180
+						</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="bgColour" type="pc:ColourSimpleType"
+					use="optional">
+					<annotation>
+						<documentation>
+							The background colour of the region
+						</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="NoiseRegionType">
+		<annotation>
+			<documentation>
+				Noise regions are regions where no real data lies, only
+				false data created by artifacts on the document or
+				scanner noise.
+			</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="pc:RegionType"></extension>
+		</complexContent>
+	</complexType>
+	<complexType name="UnknownRegionType">
+		<annotation>
+			<documentation>
+				To be used if the region type cannot be ascertained.
+			</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="pc:RegionType"></extension>
+		</complexContent>
+	</complexType>
+
+	<complexType name="PrintSpaceType">
+        <annotation>
+        	<documentation>Determines the effective area on the paper of a printed page. Its size is equal for all pages of a book (exceptions: titlepage, multipage pictures).
+It contains all living elements (except marginals) like body type, footnotes, headings, running titles.
+It does not contain pagenumber (if not part of running title), marginals, signature mark, preview words.
+</documentation>
+        </annotation>
+        <sequence>
+			<element name="Coords" type="pc:CoordsType"></element>
+		</sequence>
+	</complexType>
+
+	<complexType name="ReadingOrderType">
+        <annotation>
+        	<documentation>Definition of the reading order within the page. To express a reading order between elements they have to be included in an OrderedGroup. Groups may contain further groups.</documentation>
+        </annotation>
+        <choice minOccurs="1" maxOccurs="1">
+            <element name="OrderedGroup" type="pc:OrderedGroupType"></element>
+            <element name="UnorderedGroup" type="pc:UnorderedGroupType"></element>
+		</choice>
+	</complexType>
+
+	<complexType name="RegionRefIndexedType">
+        <annotation>
+        	<documentation>Numbered region</documentation>
+        </annotation>
+        <attribute name="index" type="int" use="required">
+			<annotation>
+				<documentation>Position (order number) of this item within the current hierarchy level.</documentation>
+			</annotation></attribute>
+        <attribute name="regionRef" type="IDREF" use="required"></attribute>
+	</complexType>
+
+	<complexType name="OrderedGroupIndexedType">
+		<annotation>
+			<documentation>
+				Indexed group containing ordered elements
+			</documentation>
+		</annotation>
+		<choice minOccurs="1" maxOccurs="unbounded">
+			<element name="RegionRefIndexed"
+				type="pc:RegionRefIndexedType">
+			</element>
+			<element name="OrderedGroupIndexed"
+				type="pc:OrderedGroupIndexedType">
+			</element>
+			<element name="UnorderedGroupIndexed"
+				type="pc:UnorderedGroupIndexedType">
+			</element>
+		</choice>
+		<attribute name="id" type="ID" use="required"></attribute>
+		<attribute name="index" type="int" use="required">
+			<annotation>
+				<documentation>
+					Position (order number) of this item within the
+					current hierarchy level.
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="caption" type="string"></attribute>
+	</complexType>
+
+	<complexType name="UnorderedGroupIndexedType">
+		<annotation>
+			<documentation>
+				Indexed group containing unordered elements
+			</documentation>
+		</annotation>
+		<choice minOccurs="1" maxOccurs="unbounded">
+			<element name="RegionRef" type="pc:RegionRefType"></element>
+			<element name="OrderedGroup" type="pc:OrderedGroupType"></element>
+			<element name="UnorderedGroup"
+				type="pc:UnorderedGroupType">
+			</element>
+		</choice>
+		<attribute name="id" type="ID" use="required"></attribute>
+		<attribute name="index" type="int" use="required">
+			<annotation>
+				<documentation>
+					Position (order number) of this item within the
+					current hierarchy level.
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="caption" type="string"></attribute>
+	</complexType>
+
+	<complexType name="RegionRefType">
+		<attribute name="regionRef" type="IDREF" use="required"></attribute>
+	</complexType>
+
+	<complexType name="OrderedGroupType">
+		<annotation>
+			<documentation>
+				Numbered group (contains ordered elements)
+			</documentation>
+		</annotation>
+		<choice minOccurs="1" maxOccurs="unbounded">
+			<element name="RegionRefIndexed"
+				type="pc:RegionRefIndexedType">
+			</element>
+			<element name="OrderedGroupIndexed"
+				type="pc:OrderedGroupIndexedType">
+			</element>
+			<element name="UnorderedGroupIndexed"
+				type="pc:UnorderedGroupIndexedType">
+			</element>
+		</choice>
+		<attribute name="id" type="ID" use="required"></attribute>
+		<attribute name="caption" type="string"></attribute>
+	</complexType>
+
+	<complexType name="UnorderedGroupType">
+		<annotation>
+			<documentation>
+				Numbered group (contains unordered elements)
+			</documentation>
+		</annotation>
+		<choice minOccurs="1" maxOccurs="unbounded">
+			<element name="RegionRef" type="pc:RegionRefType"></element>
+			<element name="OrderedGroup" type="pc:OrderedGroupType"></element>
+			<element name="UnorderedGroup"
+				type="pc:UnorderedGroupType">
+			</element>
+		</choice>
+		<attribute name="id" type="ID" use="required"></attribute>
+		<attribute name="caption" type="string"></attribute>
+	</complexType>
+
+	<complexType name="BorderType">
+        <annotation>
+        	<documentation>Border of the actual page (if the scanned image contains parts not belonging to the page).</documentation>
+        </annotation>
+        <sequence>
+			<element name="Coords" type="pc:CoordsType"></element>
+		</sequence>
+    </complexType>
+    <simpleType name="ColourSimpleType">
+    	<restriction base="string">
+    		<enumeration value="black"></enumeration>
+    		<enumeration value="blue"></enumeration>
+    		<enumeration value="brown"></enumeration>
+    		<enumeration value="cyan"></enumeration>
+    		<enumeration value="green"></enumeration>
+    		<enumeration value="grey"></enumeration>
+    		<enumeration value="indigo"></enumeration>
+    		<enumeration value="magenta"></enumeration>
+    		<enumeration value="orange"></enumeration>
+    		<enumeration value="pink"></enumeration>
+    		<enumeration value="red"></enumeration>
+    		<enumeration value="turquoise"></enumeration>
+    		<enumeration value="violet"></enumeration>
+    		<enumeration value="white"></enumeration>
+    		<enumeration value="yellow"></enumeration>
+    		<enumeration value="other"></enumeration>
+    	</restriction>
+    </simpleType>
+    <simpleType name="ReadingDirectionSimpleType">
+    	<restriction base="string">
+    		<enumeration value="left-to-right"></enumeration>
+    		<enumeration value="right-to-left"></enumeration>
+    		<enumeration value="top-to-bottom"></enumeration>
+    		<enumeration value="bottom-to-top"></enumeration>
+    	</restriction>
+    </simpleType>
+    <simpleType name="TextTypeSimpleType">
+    	<restriction base="string">
+    		<enumeration value="paragraph"></enumeration>
+    		<enumeration value="heading"></enumeration>
+    		<enumeration value="caption"></enumeration>
+    		<enumeration value="header"></enumeration>
+    		<enumeration value="footer"></enumeration>
+    		<enumeration value="page-number"></enumeration>
+    		<enumeration value="drop-capital"></enumeration>
+    		<enumeration value="credit"></enumeration>
+    		<enumeration value="floating"></enumeration>
+    		<enumeration value="signature-mark"></enumeration>
+    		<enumeration value="catch-word"></enumeration>
+    		<enumeration value="marginalia"></enumeration>
+    		<enumeration value="footnote"></enumeration>
+    		<enumeration value="footnote-continued"></enumeration>
+    		<enumeration value="endnote"></enumeration>
+    		<enumeration value="TOC-entry"></enumeration>
+    		<enumeration value="other"></enumeration>
+    	</restriction>
+    </simpleType>
+    <simpleType name="PageTypeSimpleType">
+  			<restriction base="string">
+			<enumeration value="front-cover"></enumeration>
+			<enumeration value="back-cover"></enumeration>
+			<enumeration value="title"></enumeration>
+			<enumeration value="table-of-contents"></enumeration>
+			<enumeration value="index"></enumeration>
+			<enumeration value="content"></enumeration>
+			<enumeration value="blank"></enumeration>
+			<enumeration value="other"></enumeration>
+		</restriction>
+    </simpleType>
+    
+    <simpleType name="LanguageSimpleType">
+    	<restriction base="string">
+<enumeration value="Abkhaz"></enumeration>
+<enumeration value="Afar"></enumeration>
+<enumeration value="Afrikaans"></enumeration>
+<enumeration value="Akan"></enumeration>
+<enumeration value="Albanian"></enumeration>
+<enumeration value="Amharic"></enumeration>
+<enumeration value="Arabic"></enumeration>
+<enumeration value="Aragonese"></enumeration>
+<enumeration value="Armenian"></enumeration>
+<enumeration value="Assamese"></enumeration>
+<enumeration value="Avaric"></enumeration>
+<enumeration value="Avestan"></enumeration>
+<enumeration value="Aymara"></enumeration>
+<enumeration value="Azerbaijani"></enumeration>
+<enumeration value="Bambara"></enumeration>
+<enumeration value="Bashkir"></enumeration>
+<enumeration value="Basque"></enumeration>
+<enumeration value="Belarusian"></enumeration>
+<enumeration value="Bengali"></enumeration>
+<enumeration value="Bihari"></enumeration>
+<enumeration value="Bislama"></enumeration>
+<enumeration value="Bosnian"></enumeration>
+<enumeration value="Breton"></enumeration>
+<enumeration value="Bulgarian"></enumeration>
+<enumeration value="Burmese"></enumeration>
+<enumeration value="Cambodian"></enumeration>
+<enumeration value="Cantonese"></enumeration>
+<enumeration value="Catalan"></enumeration>
+<enumeration value="Chamorro"></enumeration>
+<enumeration value="Chechen"></enumeration>
+<enumeration value="Chichewa"></enumeration>
+<enumeration value="Chinese"></enumeration>
+<enumeration value="Chuvash"></enumeration>
+<enumeration value="Cornish"></enumeration>
+<enumeration value="Corsican"></enumeration>
+<enumeration value="Cree"></enumeration>
+<enumeration value="Croatian"></enumeration>
+<enumeration value="Czech"></enumeration>
+<enumeration value="Danish"></enumeration>
+<enumeration value="Divehi"></enumeration>
+<enumeration value="Dutch"></enumeration>
+<enumeration value="Dzongkha"></enumeration>
+<enumeration value="English"></enumeration>
+<enumeration value="Esperanto"></enumeration>
+<enumeration value="Estonian"></enumeration>
+<enumeration value="Ewe"></enumeration>
+<enumeration value="Faroese"></enumeration>
+<enumeration value="Fijian"></enumeration>
+<enumeration value="Finnish"></enumeration>
+<enumeration value="French"></enumeration>
+<enumeration value="Fula"></enumeration>
+<enumeration value="Gaelic"></enumeration>
+<enumeration value="Galician"></enumeration>
+<enumeration value="Ganda"></enumeration>
+<enumeration value="Georgian"></enumeration>
+<enumeration value="German"></enumeration>
+<enumeration value="Greek"></enumeration>
+<enumeration value="Guaraní"></enumeration>
+<enumeration value="Gujarati"></enumeration>
+<enumeration value="Haitian"></enumeration>
+<enumeration value="Hausa"></enumeration>
+<enumeration value="Hebrew"></enumeration>
+<enumeration value="Herero"></enumeration>
+<enumeration value="Hindi"></enumeration>
+<enumeration value="Hiri Motu"></enumeration>
+<enumeration value="Hungarian"></enumeration>
+<enumeration value="Icelandic"></enumeration>
+<enumeration value="Ido"></enumeration>
+<enumeration value="Igbo"></enumeration>
+<enumeration value="Indonesian"></enumeration>
+<enumeration value="Interlingua"></enumeration>
+<enumeration value="Interlingue"></enumeration>
+<enumeration value="Inuktitut"></enumeration>
+<enumeration value="Inupiaq"></enumeration>
+<enumeration value="Irish"></enumeration>
+<enumeration value="Italian"></enumeration>
+<enumeration value="Japanese"></enumeration>
+<enumeration value="Javanese"></enumeration>
+<enumeration value="Kalaallisut"></enumeration>
+<enumeration value="Kannada"></enumeration>
+<enumeration value="Kanuri"></enumeration>
+<enumeration value="Kashmiri"></enumeration>
+<enumeration value="Kazakh"></enumeration>
+<enumeration value="Khmer"></enumeration>
+<enumeration value="Kikuyu"></enumeration>
+<enumeration value="Kinyarwanda"></enumeration>
+<enumeration value="Kirundi"></enumeration>
+<enumeration value="Komi"></enumeration>
+<enumeration value="Kongo"></enumeration>
+<enumeration value="Korean"></enumeration>
+<enumeration value="Kurdish"></enumeration>
+<enumeration value="Kwanyama"></enumeration>
+<enumeration value="Kyrgyz"></enumeration>
+<enumeration value="Lao"></enumeration>
+<enumeration value="Latin"></enumeration>
+<enumeration value="Latvian"></enumeration>
+<enumeration value="Limburgish"></enumeration>
+<enumeration value="Lingala"></enumeration>
+<enumeration value="Lithuanian"></enumeration>
+<enumeration value="Luba-Katanga"></enumeration>
+<enumeration value="Luxembourgish"></enumeration>
+<enumeration value="Macedonian"></enumeration>
+<enumeration value="Malagasy"></enumeration>
+<enumeration value="Malay"></enumeration>
+<enumeration value="Malayalam"></enumeration>
+<enumeration value="Maltese"></enumeration>
+<enumeration value="Manx"></enumeration>
+<enumeration value="Māori"></enumeration>
+<enumeration value="Marathi"></enumeration>
+<enumeration value="Marshallese"></enumeration>
+<enumeration value="Mongolian"></enumeration>
+<enumeration value="Nauru"></enumeration>
+<enumeration value="Navajo"></enumeration>
+<enumeration value="Ndonga"></enumeration>
+<enumeration value="Nepali"></enumeration>
+<enumeration value="North Ndebele"></enumeration>
+<enumeration value="Northern Sami"></enumeration>
+<enumeration value="Norwegian"></enumeration>
+<enumeration value="Norwegian Bokmål"></enumeration>
+<enumeration value="Norwegian Nynorsk"></enumeration>
+<enumeration value="Nuosu"></enumeration>
+<enumeration value="Occitan"></enumeration>
+<enumeration value="Ojibwe"></enumeration>
+<enumeration value="Old Church Slavonic"></enumeration>
+<enumeration value="Oriya"></enumeration>
+<enumeration value="Oromo"></enumeration>
+<enumeration value="Ossetian"></enumeration>
+<enumeration value="Pāli"></enumeration>
+<enumeration value="Panjabi"></enumeration>
+<enumeration value="Pashto"></enumeration>
+<enumeration value="Persian"></enumeration>
+<enumeration value="Polish"></enumeration>
+<enumeration value="Portuguese"></enumeration>
+<enumeration value="Punjabi"></enumeration>
+<enumeration value="Quechua"></enumeration>
+<enumeration value="Romanian"></enumeration>
+<enumeration value="Romansh"></enumeration>
+<enumeration value="Russian"></enumeration>
+<enumeration value="Samoan"></enumeration>
+<enumeration value="Sango"></enumeration>
+<enumeration value="Sanskrit"></enumeration>
+<enumeration value="Sardinian"></enumeration>
+<enumeration value="Serbian"></enumeration>
+<enumeration value="Shona"></enumeration>
+<enumeration value="Sindhi"></enumeration>
+<enumeration value="Sinhala"></enumeration>
+<enumeration value="Slovak"></enumeration>
+<enumeration value="Slovene"></enumeration>
+<enumeration value="Somali"></enumeration>
+<enumeration value="South Ndebele"></enumeration>
+<enumeration value="Southern Sotho"></enumeration>
+<enumeration value="Spanish"></enumeration>
+<enumeration value="Sundanese"></enumeration>
+<enumeration value="Swahili"></enumeration>
+<enumeration value="Swati"></enumeration>
+<enumeration value="Swedish"></enumeration>
+<enumeration value="Tagalog"></enumeration>
+<enumeration value="Tahitian"></enumeration>
+<enumeration value="Tajik"></enumeration>
+<enumeration value="Tamil"></enumeration>
+<enumeration value="Tatar"></enumeration>
+<enumeration value="Telugu"></enumeration>
+<enumeration value="Thai"></enumeration>
+<enumeration value="Tibetan"></enumeration>
+<enumeration value="Tigrinya"></enumeration>
+<enumeration value="Tonga"></enumeration>
+<enumeration value="Tsonga"></enumeration>
+<enumeration value="Tswana"></enumeration>
+<enumeration value="Turkish"></enumeration>
+<enumeration value="Turkmen"></enumeration>
+<enumeration value="Twi"></enumeration>
+<enumeration value="Uighur"></enumeration>
+<enumeration value="Ukrainian"></enumeration>
+<enumeration value="Urdu"></enumeration>
+<enumeration value="Uzbek"></enumeration>
+<enumeration value="Venda"></enumeration>
+<enumeration value="Vietnamese"></enumeration>
+<enumeration value="Volapük"></enumeration>
+<enumeration value="Walloon"></enumeration>
+<enumeration value="Welsh"></enumeration>
+<enumeration value="Western Frisian"></enumeration>
+<enumeration value="Wolof"></enumeration>
+<enumeration value="Xhosa"></enumeration>
+<enumeration value="Yiddish"></enumeration>
+<enumeration value="Yoruba"></enumeration>
+<enumeration value="Zhuang"></enumeration>
+<enumeration value="Zulu"></enumeration>
+<enumeration value="other"></enumeration>
+    	</restriction>
+    </simpleType>
+    
+    <simpleType name="ScriptSimpleType">
+    	<restriction base="string">
+    		<enumeration value="Arabic"></enumeration>
+    		<enumeration value="Bengali"></enumeration>
+    		<enumeration value="Chinese-simplified"></enumeration>
+    		<enumeration value="Chinese-traditional"></enumeration>
+    		<enumeration value="Cyrillic"></enumeration>
+    		<enumeration value="Devangari"></enumeration>
+    		<enumeration value="Ethiopic"></enumeration>
+    		<enumeration value="Greek"></enumeration>
+    		<enumeration value="Gujarati"></enumeration>
+    		<enumeration value="Gurmukhi"></enumeration>
+    		<enumeration value="Hebrew"></enumeration>
+    		<enumeration value="Latin"></enumeration>
+    		<enumeration value="Thai"></enumeration>
+    		<enumeration value="other"></enumeration>
+    	</restriction>
+    </simpleType>
+    <simpleType name="ColourDepthSimpleType">
+    	<restriction base="string">
+    		<enumeration value="bilevel"></enumeration>
+    		<enumeration value="greyscale"></enumeration>
+    		<enumeration value="colour"></enumeration>
+     		<enumeration value="other"></enumeration>
+    	</restriction>
+    </simpleType>
+    <simpleType name="GraphicsTypeSimpleType">
+    	<restriction base="string">
+    		<enumeration value="logo"></enumeration>
+    		<enumeration value="letterhead"></enumeration>
+    		<enumeration value="decoration"></enumeration>
+    		<enumeration value="frame"></enumeration>
+    		<enumeration value="handwritten-annotation"></enumeration>
+    		<enumeration value="stamp"></enumeration>
+    		<enumeration value="signature"></enumeration>
+    		<enumeration value="barcode"></enumeration>
+    		<enumeration value="paper-grow"></enumeration>
+    		<enumeration value="punch-hole"></enumeration>
+    		<enumeration value="other"></enumeration>
+    	</restriction>
+    </simpleType>
+    <simpleType name="ChartTypeSimpleType">
+    	<restriction base="string">
+    		<enumeration value="bar"></enumeration>
+    		<enumeration value="line"></enumeration>
+    		<enumeration value="pie"></enumeration>
+    		<enumeration value="scatter"></enumeration>
+    		<enumeration value="surface"></enumeration>
+    		<enumeration value="other"></enumeration>
+    	</restriction>
+    </simpleType>
+
+    <complexType name="LayersType">
+    	<annotation>
+    		<documentation>
+    			Can be used to express the z-index of overlapping
+    			regions. An element with a greater z-index is always in
+    			front of another element with lower z-index.
+    		</documentation>
+    	</annotation>
+    	<sequence minOccurs="1" maxOccurs="unbounded">
+    		<element name="Layer" type="pc:LayerType"></element>
+    	</sequence>
+    </complexType>
+    
+
+    <complexType name="LayerType">
+    	<sequence minOccurs="1" maxOccurs="unbounded">
+    		<element name="RegionRef" type="pc:RegionRefType"></element>
+    	</sequence>
+    	<attribute name="id" type="ID" use="required"></attribute>
+    	<attribute name="zIndex" type="int" use="required"></attribute>
+    	<attribute name="caption" type="string"></attribute>
+    </complexType>
+
+    
+    <complexType name="BaselineType">
+    	<attribute name="points" type="pc:PointsType" use="required"></attribute>
+    </complexType>
+
+
+    <simpleType name="PointsType">
+        <annotation>
+        	<documentation>Point list with format "x1,y1 x2,y2 ..."</documentation>
+        </annotation>
+        <restriction base="string">
+    		<pattern value="([0-9]+,[0-9]+ )+([0-9]+,[0-9]+)"></pattern>
+    	</restriction>
+    </simpleType>
+
+    <complexType name="RelationsType">
+    	<annotation>
+    		<documentation>
+    			Container for one-to-one relations between layout
+    			objects (for example: DropCap - paragraph, caption -
+    			image)
+    		</documentation>
+    	</annotation>
+    	<sequence minOccurs="1" maxOccurs="unbounded">
+    		<element name="Relation" type="pc:RelationType"></element>
+    	</sequence>
+    </complexType>
+
+    <complexType name="RelationType">
+    	<annotation>
+    		<documentation>
+    			One-to-one relation between to layout object. Use 'link'
+    			for loose relations and 'join' for strong relations
+    			(where something is fragmented for instance).
+
+    			Examples for 'link': caption - image floating -
+    			paragraph paragraph - paragraph (when a pragraph is
+    			split across columns and the last word of the first
+    			paragraph DOES NOT continue in the second paragraph)
+    			drop-cap - paragraph (when the drop-cap is a whole word)
+
+    			Examples for 'join': word - word (separated word at the
+    			end of a line) drop-cap - paragraph (when the drop-cap
+    			is not a whole word) paragraph - paragraph (when a
+    			pragraph is split across columns and the last word of
+    			the first paragraph DOES continue in the second
+    			paragraph)
+    		</documentation>
+    	</annotation>
+    	<sequence minOccurs="2" maxOccurs="2">
+    		<element name="RegionRef" type="pc:RegionRefType"></element>
+    	</sequence>
+    	<attribute name="type" use="required">
+    		<simpleType>
+    			<restriction base="string">
+    				<enumeration value="link"></enumeration>
+    				<enumeration value="join"></enumeration>
+    			</restriction>
+    		</simpleType>
+    	</attribute>
+        <attribute name="custom" type="string">
+    		<annotation>
+    			<documentation>For generic use</documentation></annotation></attribute>
+        <attribute name="comments" type="string"></attribute>
+    </complexType>
+
+    <simpleType name="ProductionSimpleType">
+        <annotation>
+        	<documentation>Text production type</documentation>
+        </annotation>
+        <restriction base="string">
+    		<enumeration value="printed"></enumeration>
+    		<enumeration value="typewritten"></enumeration>
+    		<enumeration value="handwritten-cursive"></enumeration>
+    		<enumeration value="handwritten-printscript"></enumeration>
+    		<enumeration value="medieval-manuscript"></enumeration>
+    		<enumeration value="other"></enumeration>
+    	</restriction>
+    </simpleType>
+
+    <complexType name="TextStyleType">
+    	<annotation>
+    		<documentation>
+    			Monospace (fixed-pitch, non-proportional) or
+    			proportional font
+    		</documentation>
+    	</annotation>
+    	<attribute name="fontFamily" type="string">
+    		<annotation>
+    			<documentation>
+    				For instance: Arial, Times New Roman. Add more
+    				information if necessary (e.g. blackletter,
+    				antiqua).
+    			</documentation>
+    		</annotation>
+    	</attribute>
+    	<attribute name="serif" type="boolean">
+    		<annotation>
+    			<documentation>
+    				Serif or sans-serif typeface
+    			</documentation>
+    		</annotation>
+    	</attribute>
+    	<attribute name="monospace" type="boolean"></attribute>
+    	<attribute name="fontSize" type="float">
+    		<annotation>
+    			<documentation>
+    				The size of the characters in points
+    			</documentation>
+    		</annotation>
+    	</attribute>
+    	<attribute name="kerning" type="int">
+    		<annotation>
+    			<documentation>
+    				The degree of space (in points) between the
+    				characters in a string of text
+    			</documentation>
+    		</annotation>
+    	</attribute>
+    	<attribute name="textColour" type="pc:ColourSimpleType"></attribute>
+    	<attribute name="bgColour" type="pc:ColourSimpleType">
+    		<annotation>
+    			<documentation>Background colour</documentation>
+    		</annotation>
+    	</attribute>
+    	<attribute name="reverseVideo" type="boolean">
+    		<annotation>
+    			<documentation>
+    				Specifies whether the colour of the text appears
+    				reversed against a background colour
+    			</documentation>
+    		</annotation>
+    	</attribute>
+    	<attribute name="bold" type="boolean"></attribute>
+    	<attribute name="italic" type="boolean"></attribute>
+    	<attribute name="underlined" type="boolean"></attribute>
+    	<attribute name="subscript" type="boolean"></attribute>
+    	<attribute name="superscript" type="boolean"></attribute>
+    	<attribute name="strikethrough" type="boolean"></attribute>
+        <attribute name="smallCaps" type="boolean"></attribute>
+        <attribute name="letterSpaced" type="boolean"></attribute>
+    </complexType>
+
+    <complexType name="RegionType" abstract="true">
+    	<sequence>
+    		<element name="Coords" type="pc:CoordsType"></element>
+    		<choice minOccurs="0" maxOccurs="unbounded">
+    			<element name="TextRegion" type="pc:TextRegionType"></element>
+    			<element name="ImageRegion" type="pc:ImageRegionType"></element>
+    			<element name="LineDrawingRegion"
+    				type="pc:LineDrawingRegionType">
+    			</element>
+    			<element name="GraphicRegion"
+    				type="pc:GraphicRegionType">
+    			</element>
+    			<element name="TableRegion" type="pc:TableRegionType"></element>
+    			<element name="ChartRegion" type="pc:ChartRegionType"></element>
+    			<element name="SeparatorRegion"
+    				type="pc:SeparatorRegionType">
+    			</element>
+    			<element name="MathsRegion" type="pc:MathsRegionType"></element>
+    			<element name="ChemRegion" type="pc:ChemRegionType"></element>
+    			<element name="MusicRegion" type="pc:MusicRegionType"></element>
+                <element name="AdvertRegion" type="pc:AdvertRegionType">
+    			</element>
+                <element name="NoiseRegion" type="pc:NoiseRegionType"></element>
+    			<element name="UnknownRegion" type="pc:UnknownRegionType"></element>
+    		</choice>
+    	</sequence>
+    	<attribute name="id" type="ID" use="required"></attribute>
+    	<attribute name="custom" type="string">
+    		<annotation>
+    			<documentation>For generic use</documentation>
+    		</annotation>
+    	</attribute>
+    	<attribute name="comments" type="string"></attribute>
+    </complexType>
+
+    <complexType name="AlternativeImageType">
+    	<attribute name="filename" type="string" use="required"></attribute>
+    	<attribute name="comments" type="string"></attribute>
+    </complexType>
+
+    <simpleType name="AlignSimpleType">
+    	<restriction base="string">
+    		<enumeration value="left"></enumeration>
+    		<enumeration value="centre"></enumeration>
+    		<enumeration value="right"></enumeration>
+    		<enumeration value="justify"></enumeration>
+    	</restriction>
+    </simpleType>
+</schema>

--- a/transkribus_fixer/page2019.xsd
+++ b/transkribus_fixer/page2019.xsd
@@ -1,0 +1,2665 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- defaults in XMLSchema: attribute use="optional" element minOccurs="1" maxOccurs="1" abstract="false" nillable="false" -->
+<schema targetNamespace="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"
+	xmlns:pc="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"
+	elementFormDefault="qualified"
+	xmlns="http://www.w3.org/2001/XMLSchema"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+	<element name="PcGts" type="pc:PcGtsType">
+		<annotation>
+			<documentation>Page Content - Ground Truth and Storage</documentation>
+		</annotation>
+	</element>
+	<complexType name="PcGtsType">
+		<sequence>
+			<element name="Metadata" type="pc:MetadataType"></element>
+			<element name="Page" type="pc:PageType"></element>
+		</sequence>
+		<attribute name="pcGtsId" type="ID"/>
+	</complexType>
+	<complexType name="MetadataType">
+		<sequence>
+			<element name="Creator" type="string"/>
+			<element name="Created" type="dateTime">
+				<annotation>
+					<documentation>
+					The timestamp has to be in UTC (Coordinated
+					Universal Time) and not local time.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="LastChange" type="dateTime">
+				<annotation>
+					<documentation>
+					The timestamp has to be in UTC
+					(Coordinated Universal Time)
+					and not local time.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="Comments" type="string"
+				 minOccurs="0" maxOccurs="1">
+			</element>
+			<element name="UserDefined" type="pc:UserDefinedType"
+				 minOccurs="0" maxOccurs="1">
+			</element>
+			<element name="MetadataItem" type="pc:MetadataItemType"
+				 minOccurs="0" maxOccurs="unbounded">
+			</element>
+		</sequence>
+		<attribute name="externalRef" type="string">
+			<annotation>
+				<documentation>External reference of any kind</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<complexType name="MetadataItemType">
+		<sequence>
+			<element name="Labels" type="pc:LabelsType"
+				 minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation>Semantic labels / tags</documentation>
+				</annotation>
+			</element>
+		</sequence>
+		<attribute name="type">
+			<annotation>
+				<documentation>
+				Type of metadata (e.g. author)
+				</documentation>
+			</annotation>
+			<simpleType>
+				<restriction base="string">
+					<enumeration value="author"/>
+					<enumeration value="imageProperties"/>
+					<enumeration value="processingStep"/>
+					<enumeration value="other"/>
+				</restriction>
+			</simpleType>
+		</attribute>
+		<attribute name="name" type="string">
+			<annotation>
+				<documentation>
+				E.g. imagePhotometricInterpretation
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="value" type="string" use="required">
+			<annotation>
+				<documentation>E.g. RGB</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="date" type="dateTime"/>
+	</complexType>
+	<complexType name="LabelsType">
+		<sequence>
+			<element name="Label" type="pc:LabelType"
+				 minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation>
+					A semantic label / tag
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+		<attribute name="externalModel" type="string">
+			<annotation>
+				<documentation>
+				Reference to external model / ontology / schema
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="externalId" type="string">
+			<annotation>
+				<documentation>
+				E.g. an RDF resource identifier
+				(to be used as subject or object of an RDF triple)
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="prefix" type="string">
+			<annotation>
+				<documentation>
+				Prefix for all labels (e.g. first part of an URI)
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="comments" type="string"/>
+	</complexType>
+	<complexType name="LabelType">
+		<annotation>
+			<documentation>Semantic label</documentation>
+		</annotation>
+		<attribute name="value" type="string" use="required">
+			<annotation>
+				<documentation>
+				The label / tag (e.g. 'person').
+				Can be an RDF resource identifier
+				(e.g. object of an RDF triple).
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="type" type="string">
+			<annotation>
+				<documentation>
+				Additional information on the label
+				(e.g. 'YYYY-mm-dd' for a date label).
+				Can be used as predicate of an RDF triple.
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="comments" type="string">
+		</attribute>
+	</complexType>
+	<complexType name="PageType">
+		<sequence>
+			<element name="AlternativeImage" type="pc:AlternativeImageType"
+				 minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation>
+					Alternative document page images
+					(e.g. black-and-white).
+					</documentation>
+				</annotation>
+			</element>
+			<element name="Border" type="pc:BorderType" minOccurs="0"
+				 maxOccurs="1">
+			</element>
+			<element name="PrintSpace" type="pc:PrintSpaceType"
+				 minOccurs="0" maxOccurs="1">
+			</element>
+			<element name="ReadingOrder" type="pc:ReadingOrderType"
+				 minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>Order of blocks within the page.</documentation>
+				</annotation>
+			</element>
+			<element name="Layers" type="pc:LayersType" minOccurs="0"
+				 maxOccurs="1">
+				<annotation>
+					<documentation>
+					Unassigned regions are considered to be in the
+					(virtual) default layer which is to be treated
+					as below any other layers.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="Relations" type="pc:RelationsType"
+				 minOccurs="0">
+			</element>
+			<element name="TextStyle" type="pc:TextStyleType"
+				 minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>Default text style</documentation>
+				</annotation>
+			</element>
+			<element name="UserDefined" type="pc:UserDefinedType"
+				 minOccurs="0" maxOccurs="1">
+			</element>
+			<element name="Labels" type="pc:LabelsType"
+				 minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation>Semantic labels / tags</documentation>
+				</annotation>
+			</element>
+			<choice minOccurs="0" maxOccurs="unbounded">
+				<element name="TextRegion" type="pc:TextRegionType"/>
+				<element name="ImageRegion" type="pc:ImageRegionType"/>
+				<element name="LineDrawingRegion" type="pc:LineDrawingRegionType"/>
+				<element name="GraphicRegion" type="pc:GraphicRegionType"/>
+				<element name="TableRegion" type="pc:TableRegionType"/>
+				<element name="ChartRegion" type="pc:ChartRegionType"/>
+				<element name="MapRegion" type="pc:MapRegionType"/>
+				<element name="SeparatorRegion" type="pc:SeparatorRegionType"/>
+				<element name="MathsRegion" type="pc:MathsRegionType"/>
+				<element name="ChemRegion" type="pc:ChemRegionType"/>
+				<element name="MusicRegion" type="pc:MusicRegionType"/>
+				<element name="AdvertRegion" type="pc:AdvertRegionType"/>
+				<element name="NoiseRegion" type="pc:NoiseRegionType"/>
+				<element name="UnknownRegion" type="pc:UnknownRegionType"/>
+				<element name="CustomRegion" type="pc:CustomRegionType"/>
+			</choice>
+		</sequence>
+		<attribute name="imageFilename" type="string" use="required">
+			<annotation>
+				<documentation>
+				Contains the image file name including the file extension.
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="imageWidth" type="int" use="required">
+			<annotation>
+				<documentation>Specifies the width of the image.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="imageHeight" type="int" use="required">
+			<annotation>
+				<documentation>Specifies the height of the image.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="imageXResolution" type="float">
+			<annotation>
+				<documentation>Specifies the image resolution in width.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="imageYResolution" type="float">
+			<annotation>
+				<documentation>Specifies the image resolution in height.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="imageResolutionUnit">
+			<annotation>
+				<documentation>
+				Specifies the unit of the resolution information
+				referring to a standardised unit of measurement
+				(pixels per inch, pixels per centimeter or other).
+				</documentation>
+			</annotation>
+			<simpleType>
+				<restriction base="string">
+					<enumeration value="PPI"/>
+					<enumeration value="PPCM"/>
+					<enumeration value="other"/>
+				</restriction>
+			</simpleType>
+		</attribute>
+		<attribute name="custom" type="string">
+			<annotation>
+				<documentation>For generic use</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="orientation" type="float">
+			<annotation>
+				<documentation>
+				The angle the rectangle encapsulating the page
+				(or its Border)	has to be rotated in clockwise direction
+				in order to correct the present skew
+				(negative values indicate anti-clockwise rotation).
+				(The rotated image can be further referenced
+				via “AlternativeImage”.)
+				Range: -179.999,180
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="type" type="pc:PageTypeSimpleType">
+			<annotation>
+				<documentation>
+				The type of the page within the document
+				(e.g. cover page).
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="primaryLanguage" type="pc:LanguageSimpleType">
+			<annotation>
+				<documentation>
+				The primary language used in the page
+				(lower-level definitions override the page-level definition).
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="secondaryLanguage" type="pc:LanguageSimpleType">
+			<annotation>
+				<documentation>
+				The secondary language used in the page
+				(lower-level definitions override the page-level definition).
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="primaryScript" type="pc:ScriptSimpleType">
+			<annotation>
+				<documentation>
+				The primary script used in the page
+				(lower-level definitions override the page-level definition).
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="secondaryScript" type="pc:ScriptSimpleType">
+			<annotation>
+				<documentation>
+				The secondary script used in the page
+				(lower-level definitions override the page-level definition).
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="readingDirection" type="pc:ReadingDirectionSimpleType">
+			<annotation>
+				<documentation>
+				The direction in which text within lines
+				should be read (order of words and characters),
+				in addition to “textLineOrder”
+				(lower-level definitions override the page-level definition).
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="textLineOrder"	type="pc:TextLineOrderSimpleType">
+			<annotation>
+				<documentation>
+				The order of text lines within a block,
+				in addition to “readingDirection”
+				(lower-level definitions override the page-level definition).
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="conf" type="pc:ConfSimpleType">
+			<annotation>
+				<documentation>Confidence value for whole page (between 0 and 1)</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<complexType name="TextRegionType">
+		<annotation>
+			<documentation>
+			Pure text is represented as a text region. This includes
+			drop capitals, but practically ornate text may be
+			considered as a graphic.
+			</documentation>
+		</annotation>
+		<complexContent>
+		<extension base="pc:RegionType">
+			<sequence>
+				<element name="TextLine" type="pc:TextLineType"
+					 minOccurs="0" maxOccurs="unbounded"/>
+				<element name="TextEquiv" type="pc:TextEquivType"
+					 minOccurs="0" maxOccurs="unbounded"/>
+				<element name="TextStyle" type="pc:TextStyleType"
+					 minOccurs="0" maxOccurs="1"/>
+			</sequence>
+			<attribute name="orientation" type="float">
+				<annotation>
+					<documentation>
+					The angle the rectangle encapsulating the region
+					has to be rotated in clockwise direction
+					in order to correct the present skew
+					(negative values indicate anti-clockwise rotation).
+					(The rotated image can be further referenced
+					via “AlternativeImage”.)
+					Range: -179.999,180
+					</documentation>
+				</annotation>
+			</attribute>
+			<attribute name="type" type="pc:TextTypeSimpleType">
+				<annotation>
+					<documentation>
+					The nature of the text in the region
+					</documentation>
+				</annotation>
+			</attribute>
+			<attribute name="leading" type="int">
+				<annotation>
+					<documentation>
+					The degree of space in points between the lines of
+					text (line spacing)
+					</documentation>
+				</annotation>
+			</attribute>
+			<attribute name="readingDirection" type="pc:ReadingDirectionSimpleType">
+				<annotation>
+					<documentation>
+					The direction in which text within lines
+					should be read (order of words and characters),
+					in addition to “textLineOrder”.
+					</documentation>
+				</annotation>
+			</attribute>
+			<attribute name="textLineOrder"	type="pc:TextLineOrderSimpleType">
+				<annotation>
+					<documentation>
+					The order of text lines within the block,
+					in addition to “readingDirection”.
+					</documentation>
+				</annotation>
+			</attribute>
+			<attribute name="readingOrientation" type="float">
+				<annotation>
+					<documentation>
+					The angle the baseline of text within the region
+					has to be rotated (relative to the rectangle
+					encapsulating the region) in clockwise direction
+					in order to correct the present skew,
+					in addition to “orientation”
+					(negative values indicate anti-clockwise rotation).
+					Range: -179.999,180
+					</documentation>
+				</annotation>
+			</attribute>
+			<attribute name="indented" type="boolean">
+				<annotation>
+					<documentation>
+					Defines whether a region of text is indented or not
+					</documentation>
+				</annotation>
+			</attribute>
+			<attribute name="align" type="pc:AlignSimpleType">
+				<annotation>
+					<documentation>Text align</documentation>
+				</annotation>
+			</attribute>
+			<attribute name="primaryLanguage" type="pc:LanguageSimpleType">
+				<annotation>
+					<documentation>
+					The primary language used in the region
+					</documentation>
+				</annotation>
+			</attribute>
+			<attribute name="secondaryLanguage" type="pc:LanguageSimpleType">
+				<annotation>
+					<documentation>
+					The secondary language used in the region
+					</documentation>
+				</annotation>
+			</attribute>
+			<attribute name="primaryScript" type="pc:ScriptSimpleType">
+				<annotation>
+					<documentation>
+					The primary script used in the region
+					</documentation>
+				</annotation>
+			</attribute>
+			<attribute name="secondaryScript" type="pc:ScriptSimpleType">
+				<annotation>
+					<documentation>
+					The secondary script used in the region
+					</documentation>
+				</annotation>
+			</attribute>
+			<attribute name="production" type="pc:ProductionSimpleType"/>
+		</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="CoordsType">
+		<attribute name="points" type="pc:PointsType" use="required">
+			<annotation>
+				<documentation>
+				Polygon outline of the element as a path of points.
+				No points may lie outside the outline of its parent,
+				which in the case of Border is the bounding rectangle
+				of the root image. Paths are closed by convention,
+				i.e. the last point logically connects with the first
+				(and at least 3 points are required to span an area).
+				Paths must be planar (i.e. must not self-intersect).
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="conf" type="pc:ConfSimpleType">
+			<annotation>
+				<documentation>Confidence value (between 0 and 1)</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<complexType name="TextLineType">
+		<sequence>
+			<element name="AlternativeImage" type="pc:AlternativeImageType"
+				 minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation>
+					Alternative text line images (e.g.
+					black-and-white)
+					</documentation>
+				</annotation>
+			</element>
+			<element name="Coords" type="pc:CoordsType"/>
+			<element name="Baseline" type="pc:BaselineType"
+				 minOccurs="0">
+				<annotation>
+					<documentation>
+					Multiple connected points that mark the baseline
+					of the glyphs
+					</documentation>
+				</annotation>
+			</element>
+			<element name="Word" type="pc:WordType" minOccurs="0"
+				 maxOccurs="unbounded">
+			</element>
+			<element name="TextEquiv" type="pc:TextEquivType"
+				 minOccurs="0" maxOccurs="unbounded">
+			</element>
+			<element name="TextStyle" type="pc:TextStyleType"
+				 minOccurs="0">
+			</element>
+			<element name="UserDefined" type="pc:UserDefinedType"
+				 minOccurs="0" maxOccurs="1">
+			</element>
+			<element name="Labels" type="pc:LabelsType"
+				 minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation>Semantic labels / tags</documentation>
+				</annotation>
+			</element>			
+		</sequence>
+		<attribute name="id" type="ID" use="required"/>
+		<attribute name="primaryLanguage" type="pc:LanguageSimpleType">
+			<annotation>
+				<documentation>
+				Overrides primaryLanguage attribute of parent text
+				region
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="primaryScript" type="pc:ScriptSimpleType">
+			<annotation>
+				<documentation>
+				The primary script used in the text line
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="secondaryScript" type="pc:ScriptSimpleType">
+			<annotation>
+				<documentation>
+				The secondary script used in the text line 
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="readingDirection" type="pc:ReadingDirectionSimpleType">
+			<annotation>
+				<documentation>
+				The direction in which text within the line
+				should be read (order of words and characters).
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="production" type="pc:ProductionSimpleType">
+			<annotation>
+				<documentation>
+				Overrides the production attribute of the parent
+				text region
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="custom" type="string">
+			<annotation>
+				<documentation>For generic use</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="comments" type="string"/>
+		<attribute name="index" type="int">
+			<annotation>
+				<documentation>
+				Position (order number) of this text line within the
+				parent text region.
+				</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<complexType name="WordType">
+		<sequence>
+			<element name="AlternativeImage" type="pc:AlternativeImageType"
+				 minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation>
+					Alternative word images (e.g.
+					black-and-white)
+					</documentation>
+				</annotation>
+			</element>
+			<element name="Coords" type="pc:CoordsType"/>
+			<element name="Glyph" type="pc:GlyphType" minOccurs="0"
+				maxOccurs="unbounded">
+			</element>
+			<element name="TextEquiv" type="pc:TextEquivType"
+				minOccurs="0" maxOccurs="unbounded">
+			</element>
+			<element name="TextStyle" type="pc:TextStyleType"
+				minOccurs="0">
+			</element>
+			<element name="UserDefined" type="pc:UserDefinedType"
+				 minOccurs="0" maxOccurs="1">
+			</element>
+			<element name="Labels" type="pc:LabelsType" minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation>Semantic labels / tags</documentation>
+				</annotation>
+			</element>			
+		</sequence>
+		<attribute name="id" type="ID" use="required"/>
+		<attribute name="language" type="pc:LanguageSimpleType">
+			<annotation>
+				<documentation>
+				Overrides primaryLanguage attribute of parent line
+				and/or text region
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="primaryScript" type="pc:ScriptSimpleType">
+			<annotation>
+				<documentation>
+				The primary script used in the word
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="secondaryScript" type="pc:ScriptSimpleType">
+			<annotation>
+				<documentation>
+				The secondary script used in the word 
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="readingDirection" type="pc:ReadingDirectionSimpleType">
+			<annotation>
+				<documentation>
+				The direction in which text within the word
+				should be read (order of characters).
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="production" type="pc:ProductionSimpleType">
+			<annotation>
+				<documentation>
+				Overrides the production attribute of the parent
+				text line and/or text region.
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="custom" type="string">
+			<annotation>
+				<documentation>For generic use</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="comments" type="string"/>
+	</complexType>
+	<complexType name="GlyphType">
+		<sequence>
+			<element name="AlternativeImage" type="pc:AlternativeImageType"
+				 minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation>
+					Alternative glyph images (e.g.
+					black-and-white)
+					</documentation>
+				</annotation>
+			</element>
+			<element name="Coords" type="pc:CoordsType"/>
+			<element name="Graphemes" type="pc:GraphemesType"
+				 minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					Container for graphemes, grapheme groups and
+					non-printing characters
+					</documentation>
+				</annotation>
+			</element>
+			<element name="TextEquiv" type="pc:TextEquivType"
+				 minOccurs="0" maxOccurs="unbounded">
+			</element>
+			<element name="TextStyle" type="pc:TextStyleType"
+				 minOccurs="0">
+			</element>
+			<element name="UserDefined" type="pc:UserDefinedType"
+				 minOccurs="0" maxOccurs="1">
+			</element>
+			<element name="Labels" type="pc:LabelsType"
+				 minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation>Semantic labels / tags</documentation>
+				</annotation>
+			</element>
+		</sequence>
+		<attribute name="id" type="ID" use="required"/>
+		<attribute name="ligature" use="optional" type="boolean"/>
+		<attribute name="symbol" use="optional" type="boolean"/>
+		<attribute name="script" type="pc:ScriptSimpleType">
+			<annotation>
+				<documentation>
+				The script used for the glyph
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="production" type="pc:ProductionSimpleType">
+			<annotation>
+				<documentation>
+				Overrides the production attribute of the parent
+				word / text line / text region.
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="custom" type="string">
+			<annotation>
+				<documentation>For generic use</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="comments" type="string"/>
+	</complexType>
+	<complexType name="TextEquivType">
+		<sequence>
+			<element name="PlainText" type="string" minOccurs="0">
+				<annotation>
+					<documentation>
+					Text in a "simple" form (ASCII or extended ASCII
+					as mostly used for typing). I.e. no use of
+					special characters for ligatures (should be
+					stored as two separate characters) etc.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="Unicode" type="string">
+				<annotation>
+					<documentation>
+					Correct encoding of the original, always using
+					the corresponding Unicode code point. I.e.
+					ligatures have to be represented as one
+					character etc.
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+		<attribute name="index" use="optional">
+			<annotation>
+				<documentation>
+				Used for sort order in case multiple TextEquivs are defined.
+				The text content with the lowest index should be interpreted
+				as the main text content.
+				</documentation>
+			</annotation>
+			<simpleType>
+				<restriction base="integer">
+					<minInclusive value="0"></minInclusive>
+				</restriction>
+			</simpleType>
+		</attribute>
+		<attribute name="conf" type="pc:ConfSimpleType">
+			<annotation>
+				<documentation>OCR confidence value (between 0 and 1)</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="dataType" type="pc:TextDataTypeSimpleType">
+			<annotation>
+				<documentation>
+				Type of text content (is it free text or a number, for instance).
+				This is only a descriptive attribute, the text type
+				is not checked during XML validation.
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="dataTypeDetails" type="string">
+			<annotation>
+				<documentation>
+				Refinement for dataType attribute. Can be a regular expression, for instance.
+				</documentation>
+			</annotation>
+		</attribute>
+		<!-- <attribute name="mergeWithNextRule" type="pc:TextMergeRuleSimpleType">
+				<annotation>
+					<documentation>Rule for merging consecutive text objects. The rule applies to the first object of a pair (i.e. 'remove-last' removes the last
+		character of the first region, can be used to remove hyphen, for example)</documentation>
+				</annotation>
+		</attribute>
+		<attribute name="mergeWithNextRuleData" type="string">
+				<annotation>
+					<documentation>Custom data for mergeRule attribute. Can number of characters to be removed, for example.</documentation>
+				</annotation>
+		</attribute> -->
+		<attribute name="comments" type="string"/>
+	</complexType>
+	<complexType name="ImageRegionType">
+		<annotation>
+			<documentation>
+			An image is considered to be more intricate and complex
+			than a graphic. These can be photos or drawings.
+			</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="pc:RegionType">
+				<attribute name="orientation" type="float">
+					<annotation>
+						<documentation>
+						The angle the rectangle encapsulating a region
+						has to be rotated in clockwise direction
+						in order to correct the present skew
+						(negative values indicate anti-clockwise rotation).
+						Range: -179.999,180
+						</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="colourDepth" type="pc:ColourDepthSimpleType">
+					<annotation>
+						<documentation>
+						The colour bit depth required for the region
+						</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="bgColour" type="pc:ColourSimpleType">
+					<annotation>
+						<documentation>
+						The background colour of the region
+						</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="embText" type="boolean">
+					<annotation>
+						<documentation>
+						Specifies whether the region also contains
+						text
+						</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="LineDrawingRegionType">
+		<annotation>
+			<documentation>
+			A line drawing is a single colour illustration without
+			solid areas.
+			</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="pc:RegionType">
+				<attribute name="orientation" type="float">
+					<annotation>
+						<documentation>
+						The angle the rectangle encapsulating a region
+						has to be rotated in clockwise direction
+						in order to correct the present skew
+						(negative values indicate anti-clockwise rotation).
+						Range: -179.999,180
+						</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="penColour" type="pc:ColourSimpleType">
+					<annotation>
+						<documentation>
+						The pen (foreground) colour of the region
+						</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="bgColour" type="pc:ColourSimpleType">
+					<annotation>
+						<documentation>
+						The background colour of the region
+						</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="embText" type="boolean">
+					<annotation>
+						<documentation>
+						Specifies whether the region also contains
+						text
+						</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="GraphicRegionType">
+		<annotation>
+			<documentation>
+			Regions containing simple graphics, such as a company
+			logo, should be marked as graphic regions.
+			</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="pc:RegionType">
+				<attribute name="orientation" type="float">
+					<annotation>
+						<documentation>
+						The angle the rectangle encapsulating a region
+						has to be rotated in clockwise direction
+						in order to correct the present skew
+						(negative values indicate anti-clockwise rotation).
+						Range: -179.999,180
+						</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="type" type="pc:GraphicsTypeSimpleType">
+					<annotation>
+						<documentation>
+						The type of graphic in the region
+						</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="numColours" type="int">
+					<annotation>
+						<documentation>
+						An approximation of the number of colours
+						used in the region
+						</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="embText" type="boolean">
+					<annotation>
+						<documentation>
+						Specifies whether the region also contains
+						text.
+						</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="TableRegionType">
+		<annotation>
+			<documentation>
+			Tabular data in any form is represented with a table
+			region. Rows and columns may or may not have separator
+			lines; these lines are not separator regions.
+			</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="pc:RegionType">
+				<sequence>
+					<element name="Grid" type="pc:GridType"
+						 minOccurs="0" maxOccurs="1">
+						<annotation>
+							<documentation>Table grid (visible or virtual grid lines)</documentation>
+						</annotation>
+					</element>
+				</sequence>
+				<attribute name="orientation" type="float">
+					<annotation>
+						<documentation>
+						The angle the rectangle encapsulating a	region
+						has to be rotated in clockwise direction
+						in order to correct the present	skew
+						(negative values indicate anti-clockwise rotation).
+						Range: -179.999,180
+						</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="rows" type="int">
+					<annotation>
+						<documentation>
+						The number of rows present in the table
+						</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="columns" type="int">
+					<annotation>
+						<documentation>
+						The number of columns present in the table
+						</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="lineColour" type="pc:ColourSimpleType">
+					<annotation>
+						<documentation>
+						The colour of the lines used in the region
+						</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="bgColour" type="pc:ColourSimpleType">
+					<annotation>
+						<documentation>
+						The background colour of the region
+						</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="lineSeparators" type="boolean">
+					<annotation>
+						<documentation>
+						Specifies the presence of line separators
+						</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="embText" type="boolean">
+					<annotation>
+						<documentation>
+						Specifies whether the region also contains
+						text
+						</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="GridType">
+		<annotation>
+			<documentation>
+			Matrix of grid points defining the table grid on the page.
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="GridPoints" type="pc:GridPointsType"
+				 minOccurs="2" maxOccurs="unbounded">
+				<annotation>
+					<documentation>
+					One row in the grid point matrix.
+					Points with x,y coordinates.
+					(note: for a table with n table rows there should be n+1 grid rows)
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="GridPointsType">
+		<annotation>
+			<documentation>Points with x,y coordinates.</documentation>
+		</annotation>
+		<attribute name="index" type="int" use="required">
+			<annotation>
+				<documentation>
+				The grid row index
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="points" type="pc:PointsType"
+			   use="required"/>
+	</complexType>
+	<complexType name="ChartRegionType">
+		<annotation>
+			<documentation>
+			Regions containing charts or graphs of any type, should
+			be marked as chart regions.
+			</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="pc:RegionType">
+				<attribute name="orientation" type="float">
+					<annotation>
+						<documentation>
+						The angle the rectangle encapsulating a region
+						has to be rotated in clockwise direction
+						in order to correct the present skew
+						(negative values indicate anti-clockwise rotation).
+						Range: -179.999,180
+						</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="type" type="pc:ChartTypeSimpleType">
+					<annotation>
+						<documentation>
+						The type of chart in the region
+						</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="numColours" type="int">
+					<annotation>
+						<documentation>
+						An approximation of the number of colours
+						used in the region
+						</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="bgColour" type="pc:ColourSimpleType">
+					<annotation>
+						<documentation>
+						The background colour of the region
+						</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="embText" type="boolean">
+					<annotation>
+						<documentation>
+						Specifies whether the region also contains
+						text
+						</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="SeparatorRegionType">
+		<annotation>
+			<documentation>
+			Separators are lines that lie between columns and
+			paragraphs and can be used to logically separate
+			different articles from each other.
+			</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="pc:RegionType">
+				<attribute name="orientation" type="float">
+					<annotation>
+						<documentation>
+						The angle the rectangle encapsulating a region
+						has to be rotated in clockwise direction
+						in order to correct the present skew
+						(negative values indicate anti-clockwise rotation).
+						Range: -179.999,180
+						</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="colour" type="pc:ColourSimpleType">
+					<annotation>
+						<documentation>
+						The colour of the separator
+						</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="MathsRegionType">
+		<annotation>
+			<documentation>
+			Regions containing equations and mathematical symbols
+			should be marked as maths regions.
+			</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="pc:RegionType">
+				<attribute name="orientation" type="float">
+					<annotation>
+						<documentation>
+						The angle the rectangle encapsulating a region
+						has to be rotated in clockwise direction
+						in order to correct the present skew
+						(negative values indicate anti-clockwise rotation).
+						Range: -179.999,180
+						</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="bgColour" type="pc:ColourSimpleType">
+					<annotation>
+						<documentation>
+						The background colour of the region
+						</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="ChemRegionType">
+		<annotation>
+			<documentation>
+			Regions containing chemical formulas.
+			</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="pc:RegionType">
+				<attribute name="orientation" type="float">
+					<annotation>
+						<documentation>
+						The angle the rectangle encapsulating a
+						region has to be rotated in clockwise
+						direction in order to correct the present
+						skew (negative values indicate
+						anti-clockwise rotation). Range:
+						-179.999,180
+						</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="bgColour" type="pc:ColourSimpleType">
+					<annotation>
+						<documentation>
+						The background colour of the region
+						</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="MapRegionType">
+		<annotation>
+			<documentation>
+			Regions containing maps.
+			</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="pc:RegionType">
+				<attribute name="orientation" type="float">
+					<annotation>
+						<documentation>
+						The angle the rectangle encapsulating a
+						region has to be rotated in clockwise
+						direction in order to correct the present
+						skew (negative values indicate
+						anti-clockwise rotation). Range:
+						-179.999,180
+						</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="MusicRegionType">
+		<annotation>
+			<documentation>
+			Regions containing musical notations.
+			</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="pc:RegionType">
+				<attribute name="orientation" type="float">
+					<annotation>
+						<documentation>
+						The angle the rectangle encapsulating a region
+						has to be rotated in clockwise direction
+						in order to correct the present skew
+						(negative values indicate anti-clockwise rotation).
+						Range: -179.999,180
+						</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="bgColour" type="pc:ColourSimpleType">
+					<annotation>
+						<documentation>
+						The background colour of the region
+						</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="AdvertRegionType">
+		<annotation>
+			<documentation>
+			Regions containing advertisements.
+			</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="pc:RegionType">
+				<attribute name="orientation" type="float">
+					<annotation>
+						<documentation>
+						The angle the rectangle encapsulating a region
+						has to be rotated in clockwise direction
+						in order to correct the present skew
+						(negative values indicate anti-clockwise rotation).
+						Range: -179.999,180
+						</documentation>
+					</annotation>
+				</attribute>
+				<attribute name="bgColour" type="pc:ColourSimpleType">
+					<annotation>
+						<documentation>
+						The background colour of the region
+						</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="NoiseRegionType">
+		<annotation>
+			<documentation>
+			Noise regions are regions where no real data lies, only
+			false data created by artifacts on the document or
+			scanner noise.
+			</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="pc:RegionType"></extension>
+		</complexContent>
+	</complexType>
+	<complexType name="UnknownRegionType">
+		<annotation>
+			<documentation>
+			To be used if the region type cannot be ascertained.
+			</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="pc:RegionType"></extension>
+		</complexContent>
+	</complexType>
+	<complexType name="CustomRegionType">
+		<annotation>
+			<documentation>
+			Regions containing content that is not covered
+			by the default types (text, graphic, image,
+			line drawing, chart, table, separator, maths,
+			map, music, chem, advert, noise, unknown).
+			</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="pc:RegionType">
+				<attribute name="type" type="string">
+					<annotation>
+						<documentation>
+						Information on the type of content represented by this region
+						</documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="PrintSpaceType">
+		<annotation>
+			<documentation>
+			Determines the effective area on the paper of a printed page.
+			Its size is equal for all pages of a book
+			(exceptions: titlepage, multipage pictures).
+			It contains all living elements (except marginals)
+			like body type, footnotes, headings, running titles.
+			It does not contain pagenumber (if not part of running title),
+			marginals, signature mark, preview words.
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="Coords" type="pc:CoordsType"/>
+		</sequence>
+	</complexType>
+	<complexType name="ReadingOrderType">
+		<annotation>
+			<documentation>
+			Definition of the reading order within the page.
+			To express a reading order between regions,
+			they have to be referenced by an OrderedGroup.
+			To express a non-sequential relationship (while still
+			referencing them as part of the overall structural tree),
+			they have to be referenced by an UnorderedGroup.
+			Groups may contain further groups, just as regions may
+			contain further regions.
+			</documentation>
+		</annotation>
+		<choice minOccurs="1" maxOccurs="1">
+			<element name="OrderedGroup" type="pc:OrderedGroupType"/>
+			<element name="UnorderedGroup" type="pc:UnorderedGroupType"/>
+		</choice>
+		<attribute name="conf" type="pc:ConfSimpleType">
+			<annotation>
+				<documentation>Confidence value (between 0 and 1)</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<complexType name="RegionRefType">
+		<annotation>
+			<documentation>Region reference in an UnorderedGroup(Indexed)</documentation>
+		</annotation>
+		<attribute name="regionRef" type="IDREF" use="required"/>
+	</complexType>
+	<complexType name="OrderedGroupType">
+		<annotation>
+			<documentation>
+			Group containing index-ordered elements within an UnorderedGroup(Indexed)
+			Elements must be sorted ascending strictly monotonically according to their
+			@index, regardless of their type. (That is, the index of each two consecutive
+			OrderedGroupIndexed, UnorderedGroupIndexed or RegionRefIndexed elements
+			must increase by at least one.)
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="UserDefined" type="pc:UserDefinedType"
+				 minOccurs="0" maxOccurs="1">
+			</element>
+			<element name="Labels" type="pc:LabelsType"
+				 minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation>Semantic labels / tags</documentation>
+				</annotation>
+			</element>
+			<choice minOccurs="1" maxOccurs="unbounded">
+				<element name="RegionRefIndexed" type="pc:RegionRefIndexedType"/>
+				<element name="OrderedGroupIndexed" type="pc:OrderedGroupIndexedType"/>
+				<element name="UnorderedGroupIndexed" type="pc:UnorderedGroupIndexedType"/>
+			</choice>
+		</sequence>
+		<attribute name="id" type="ID" use="required"/>
+		<attribute name="regionRef" type="IDREF">
+			<annotation>
+				<documentation>
+				Optional link to a parent region of nested regions.
+				The parent region doubles as reading order group.
+				Only the nested regions should be allowed as group members.
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="caption" type="string"/>
+		<attribute name="type" type="pc:GroupTypeSimpleType"/>
+		<attribute name="continuation" type="boolean">
+			<annotation>
+				<documentation>
+				Is this group a continuation of another group
+				(from previous column or page, for example)?
+				</documentation>
+        		</annotation>
+		</attribute>
+		<attribute name="custom" type="string">
+			<annotation>
+				<documentation>For generic use</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="comments" type="string"/>
+	</complexType>
+	<complexType name="UnorderedGroupType">
+		<annotation>
+			<documentation>
+			Group containing unordered elements within an UnorderedGroup(Indexed)
+			Elements need not be sorted, and may be mixed by type. (That is,
+			the sequence of	OrderedGroup, UnorderedGroup or RegionRef elements
+			may be ordered arbitrarily.)
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="UserDefined" type="pc:UserDefinedType"
+				 minOccurs="0" maxOccurs="1">
+			</element>
+			<element name="Labels" type="pc:LabelsType"
+				 minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation>Semantic labels / tags</documentation>
+				</annotation>
+			</element>
+			<choice minOccurs="1" maxOccurs="unbounded">
+				<element name="RegionRef" type="pc:RegionRefType"/>
+				<element name="OrderedGroup" type="pc:OrderedGroupType"/>
+				<element name="UnorderedGroup" type="pc:UnorderedGroupType"/>
+			</choice>
+		</sequence>
+		<attribute name="id" type="ID" use="required"/>
+		<attribute name="regionRef" type="IDREF">
+			<annotation>
+				<documentation>
+				Optional link to a parent region of nested regions.
+				The parent region doubles as reading order group.
+				Only the nested regions should be allowed as group members.
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="caption" type="string"/>
+		<attribute name="type" type="pc:GroupTypeSimpleType"/>
+		<attribute name="continuation" type="boolean">
+			<annotation>
+				<documentation>
+				Is this group a continuation of another group
+				(from previous column or page, for example)?
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="custom" type="string">
+			<annotation>
+				<documentation>For generic use</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="comments" type="string"/>
+	</complexType>
+	<complexType name="RegionRefIndexedType">
+		<annotation>
+			<documentation>Region reference within an OrderedGroup(Indexed)</documentation>
+		</annotation>
+		<attribute name="index" type="int" use="required">
+			<annotation>
+				<documentation>Position (order number) of this item within the current hierarchy level.</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="regionRef" type="IDREF" use="required"/>
+	</complexType>
+	<complexType name="OrderedGroupIndexedType">
+		<annotation>
+			<documentation>
+			Group containing index-ordered elements within an OrderedGroup(Indexed).
+			Elements must be sorted ascending strictly monotonically according to their
+			@index, regardless of their type. (That is, the index of each two consecutive
+			OrderedGroupIndexed, UnorderedGroupIndexed or RegionRefIndexed elements
+			must increase by at least one.)
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="UserDefined" type="pc:UserDefinedType"
+				 minOccurs="0" maxOccurs="1"/>
+			<element name="Labels" type="pc:LabelsType"
+				 minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation>Semantic labels / tags</documentation>
+				</annotation>
+			</element>
+			<choice minOccurs="1" maxOccurs="unbounded">
+				<element name="RegionRefIndexed" type="pc:RegionRefIndexedType"/>
+				<element name="OrderedGroupIndexed" type="pc:OrderedGroupIndexedType"/>
+				<element name="UnorderedGroupIndexed" type="pc:UnorderedGroupIndexedType"/>
+			</choice>
+		</sequence>
+		<attribute name="id" type="ID" use="required"/>
+		<attribute name="regionRef" type="IDREF">
+			<annotation>
+				<documentation>
+				Optional link to a parent region of nested regions.
+				The parent region doubles as reading order group.
+				Only the nested regions should be allowed as group members.
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="index" type="int" use="required">
+			<annotation>
+				<documentation>
+				Position (order number) of this item within the
+				current hierarchy level.
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="caption" type="string"/>
+		<attribute name="type" type="pc:GroupTypeSimpleType"/>
+		<attribute name="continuation" type="boolean">
+			<annotation>
+				<documentation>
+				Is this group a continuation of another group (from
+				previous column or page, for example)?
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="custom" type="string">
+			<annotation>
+				<documentation>For generic use</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="comments" type="string"/>
+	</complexType>
+	<complexType name="UnorderedGroupIndexedType">
+		<annotation>
+			<documentation>
+			Group containing unordered elements within an OrderedGroup(Indexed)
+			Elements need not be sorted, and may be mixed by type. (That is,
+			the sequence of	OrderedGroup, UnorderedGroup or RegionRef elements
+			may be ordered arbitrarily.)
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="UserDefined" type="pc:UserDefinedType"
+				 minOccurs="0" maxOccurs="1">
+			</element>
+			<element name="Labels" type="pc:LabelsType"
+				 minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation>Semantic labels / tags</documentation>
+				</annotation>
+			</element>
+			<choice minOccurs="1" maxOccurs="unbounded">
+				<element name="RegionRef" type="pc:RegionRefType"/>
+				<element name="OrderedGroup" type="pc:OrderedGroupType"/>
+				<element name="UnorderedGroup" type="pc:UnorderedGroupType"/>
+			</choice>
+		</sequence>
+		<attribute name="id" type="ID" use="required"/>
+		<attribute name="regionRef" type="IDREF">
+			<annotation>
+				<documentation>
+				Optional link to a parent region of nested regions.
+				The parent region doubles as reading order group.
+				Only the nested regions should be allowed as group members.
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="index" type="int" use="required">
+			<annotation>
+				<documentation>
+				Position (order number) of this item within the
+				current hierarchy level.
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="caption" type="string"/>
+		<attribute name="type" type="pc:GroupTypeSimpleType"/>
+		<attribute name="continuation" type="boolean">
+			<annotation>
+				<documentation>
+				Is this group a continuation of another group
+				(from previous column or page, for example)?
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="custom" type="string">
+			<annotation>
+				<documentation>For generic use</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="comments" type="string"/>
+	</complexType>
+	<complexType name="BorderType">
+		<annotation>
+			<documentation>
+			Border of the actual page (if the scanned image
+			contains parts not belonging to the page).
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="Coords" type="pc:CoordsType"/>
+		</sequence>
+	</complexType>
+	<simpleType name="ColourSimpleType">
+		<restriction base="string">
+			<enumeration value="black"/>
+			<enumeration value="blue"/>
+			<enumeration value="brown"/>
+			<enumeration value="cyan"/>
+			<enumeration value="green"/>
+			<enumeration value="grey"/>
+			<enumeration value="indigo"/>
+			<enumeration value="magenta"/>
+			<enumeration value="orange"/>
+			<enumeration value="pink"/>
+			<enumeration value="red"/>
+			<enumeration value="turquoise"/>
+			<enumeration value="violet"/>
+			<enumeration value="white"/>
+			<enumeration value="yellow"/>
+			<enumeration value="other"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="ReadingDirectionSimpleType">
+		<restriction base="string">
+			<enumeration value="left-to-right"/>
+			<enumeration value="right-to-left"/>
+			<enumeration value="top-to-bottom"/>
+			<enumeration value="bottom-to-top"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="TextLineOrderSimpleType">
+		<restriction base="string">
+			<enumeration value="top-to-bottom"/>
+			<enumeration value="bottom-to-top"/>
+			<enumeration value="left-to-right"/>
+			<enumeration value="right-to-left"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="TextTypeSimpleType">
+		<restriction base="string">
+			<enumeration value="paragraph"/>
+			<enumeration value="heading"/>
+			<enumeration value="caption"/>
+			<enumeration value="header"/>
+			<enumeration value="footer"/>
+			<enumeration value="page-number"/>
+			<enumeration value="drop-capital"/>
+			<enumeration value="credit"/>
+			<enumeration value="floating"/>
+			<enumeration value="signature-mark"/>
+			<enumeration value="catch-word"/>
+			<enumeration value="marginalia"/>
+			<enumeration value="footnote"/>
+			<enumeration value="footnote-continued"/>
+			<enumeration value="endnote"/>
+			<enumeration value="TOC-entry"/>
+			<enumeration value="list-label"/>
+			<enumeration value="other"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="PageTypeSimpleType">
+		<restriction base="string">
+			<enumeration value="front-cover"/>
+			<enumeration value="back-cover"/>
+			<enumeration value="title"/>
+			<enumeration value="table-of-contents"/>
+			<enumeration value="index"/>
+			<enumeration value="content"/>
+			<enumeration value="blank"/>
+			<enumeration value="other"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="ConfSimpleType">
+		<restriction base="float">
+			<minInclusive value="0"></minInclusive>
+			<maxInclusive value="1"></maxInclusive>
+		</restriction>
+	</simpleType>
+	<simpleType name="LanguageSimpleType">
+		<annotation>
+			<documentation>ISO 639.x 2016-07-14</documentation>
+		</annotation>
+		<restriction base="string">
+			<enumeration value="Abkhaz"/>
+			<enumeration value="Afar"/>
+			<enumeration value="Afrikaans"/>
+			<enumeration value="Akan"/>
+			<enumeration value="Albanian"/>
+			<enumeration value="Amharic"/>
+			<enumeration value="Arabic"/>
+			<enumeration value="Aragonese"/>
+			<enumeration value="Armenian"/>
+			<enumeration value="Assamese"/>
+			<enumeration value="Avaric"/>
+			<enumeration value="Avestan"/>
+			<enumeration value="Aymara"/>
+			<enumeration value="Azerbaijani"/>
+			<enumeration value="Bambara"/>
+			<enumeration value="Bashkir"/>
+			<enumeration value="Basque"/>
+			<enumeration value="Belarusian"/>
+			<enumeration value="Bengali"/>
+			<enumeration value="Bihari"/>
+			<enumeration value="Bislama"/>
+			<enumeration value="Bosnian"/>
+			<enumeration value="Breton"/>
+			<enumeration value="Bulgarian"/>
+			<enumeration value="Burmese"/>
+			<enumeration value="Cambodian"/>
+			<enumeration value="Cantonese"/>
+			<enumeration value="Catalan"/>
+			<enumeration value="Chamorro"/>
+			<enumeration value="Chechen"/>
+			<enumeration value="Chichewa"/>
+			<enumeration value="Chinese"/>
+			<enumeration value="Chuvash"/>
+			<enumeration value="Cornish"/>
+			<enumeration value="Corsican"/>
+			<enumeration value="Cree"/>
+			<enumeration value="Croatian"/>
+			<enumeration value="Czech"/>
+			<enumeration value="Danish"/>
+			<enumeration value="Divehi"/>
+			<enumeration value="Dutch"/>
+			<enumeration value="Dzongkha"/>
+			<enumeration value="English"/>
+			<enumeration value="Esperanto"/>
+			<enumeration value="Estonian"/>
+			<enumeration value="Ewe"/>
+			<enumeration value="Faroese"/>
+			<enumeration value="Fijian"/>
+			<enumeration value="Finnish"/>
+			<enumeration value="French"/>
+			<enumeration value="Fula"/>
+			<enumeration value="Gaelic"/>
+			<enumeration value="Galician"/>
+			<enumeration value="Ganda"/>
+			<enumeration value="Georgian"/>
+			<enumeration value="German"/>
+			<enumeration value="Greek"/>
+			<enumeration value="Guaraní"/>
+			<enumeration value="Gujarati"/>
+			<enumeration value="Haitian"/>
+			<enumeration value="Hausa"/>
+			<enumeration value="Hebrew"/>
+			<enumeration value="Herero"/>
+			<enumeration value="Hindi"/>
+			<enumeration value="Hiri Motu"/>
+			<enumeration value="Hungarian"/>
+			<enumeration value="Icelandic"/>
+			<enumeration value="Ido"/>
+			<enumeration value="Igbo"/>
+			<enumeration value="Indonesian"/>
+			<enumeration value="Interlingua"/>
+			<enumeration value="Interlingue"/>
+			<enumeration value="Inuktitut"/>
+			<enumeration value="Inupiaq"/>
+			<enumeration value="Irish"/>
+			<enumeration value="Italian"/>
+			<enumeration value="Japanese"/>
+			<enumeration value="Javanese"/>
+			<enumeration value="Kalaallisut"/>
+			<enumeration value="Kannada"/>
+			<enumeration value="Kanuri"/>
+			<enumeration value="Kashmiri"/>
+			<enumeration value="Kazakh"/>
+			<enumeration value="Khmer"/>
+			<enumeration value="Kikuyu"/>
+			<enumeration value="Kinyarwanda"/>
+			<enumeration value="Kirundi"/>
+			<enumeration value="Komi"/>
+			<enumeration value="Kongo"/>
+			<enumeration value="Korean"/>
+			<enumeration value="Kurdish"/>
+			<enumeration value="Kwanyama"/>
+			<enumeration value="Kyrgyz"/>
+			<enumeration value="Lao"/>
+			<enumeration value="Latin"/>
+			<enumeration value="Latvian"/>
+			<enumeration value="Limburgish"/>
+			<enumeration value="Lingala"/>
+			<enumeration value="Lithuanian"/>
+			<enumeration value="Luba-Katanga"/>
+			<enumeration value="Luxembourgish"/>
+			<enumeration value="Macedonian"/>
+			<enumeration value="Malagasy"/>
+			<enumeration value="Malay"/>
+			<enumeration value="Malayalam"/>
+			<enumeration value="Maltese"/>
+			<enumeration value="Manx"/>
+			<enumeration value="Māori"/>
+			<enumeration value="Marathi"/>
+			<enumeration value="Marshallese"/>
+			<enumeration value="Mongolian"/>
+			<enumeration value="Nauru"/>
+			<enumeration value="Navajo"/>
+			<enumeration value="Ndonga"/>
+			<enumeration value="Nepali"/>
+			<enumeration value="North Ndebele"/>
+			<enumeration value="Northern Sami"/>
+			<enumeration value="Norwegian"/>
+			<enumeration value="Norwegian Bokmål"/>
+			<enumeration value="Norwegian Nynorsk"/>
+			<enumeration value="Nuosu"/>
+			<enumeration value="Occitan"/>
+			<enumeration value="Ojibwe"/>
+			<enumeration value="Old Church Slavonic"/>
+			<enumeration value="Oriya"/>
+			<enumeration value="Oromo"/>
+			<enumeration value="Ossetian"/>
+			<enumeration value="Pāli"/>
+			<enumeration value="Panjabi"/>
+			<enumeration value="Pashto"/>
+			<enumeration value="Persian"/>
+			<enumeration value="Polish"/>
+			<enumeration value="Portuguese"/>
+			<enumeration value="Punjabi"/>
+			<enumeration value="Quechua"/>
+			<enumeration value="Romanian"/>
+			<enumeration value="Romansh"/>
+			<enumeration value="Russian"/>
+			<enumeration value="Samoan"/>
+			<enumeration value="Sango"/>
+			<enumeration value="Sanskrit"/>
+			<enumeration value="Sardinian"/>
+			<enumeration value="Serbian"/>
+			<enumeration value="Shona"/>
+			<enumeration value="Sindhi"/>
+			<enumeration value="Sinhala"/>
+			<enumeration value="Slovak"/>
+			<enumeration value="Slovene"/>
+			<enumeration value="Somali"/>
+			<enumeration value="South Ndebele"/>
+			<enumeration value="Southern Sotho"/>
+			<enumeration value="Spanish"/>
+			<enumeration value="Sundanese"/>
+			<enumeration value="Swahili"/>
+			<enumeration value="Swati"/>
+			<enumeration value="Swedish"/>
+			<enumeration value="Tagalog"/>
+			<enumeration value="Tahitian"/>
+			<enumeration value="Tajik"/>
+			<enumeration value="Tamil"/>
+			<enumeration value="Tatar"/>
+			<enumeration value="Telugu"/>
+			<enumeration value="Thai"/>
+			<enumeration value="Tibetan"/>
+			<enumeration value="Tigrinya"/>
+			<enumeration value="Tonga"/>
+			<enumeration value="Tsonga"/>
+			<enumeration value="Tswana"/>
+			<enumeration value="Turkish"/>
+			<enumeration value="Turkmen"/>
+			<enumeration value="Twi"/>
+			<enumeration value="Uighur"/>
+			<enumeration value="Ukrainian"/>
+			<enumeration value="Urdu"/>
+			<enumeration value="Uzbek"/>
+			<enumeration value="Venda"/>
+			<enumeration value="Vietnamese"/>
+			<enumeration value="Volapük"/>
+			<enumeration value="Walloon"/>
+			<enumeration value="Welsh"/>
+			<enumeration value="Western Frisian"/>
+			<enumeration value="Wolof"/>
+			<enumeration value="Xhosa"/>
+			<enumeration value="Yiddish"/>
+			<enumeration value="Yoruba"/>
+			<enumeration value="Zhuang"/>
+			<enumeration value="Zulu"/>
+			<enumeration value="other"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="ScriptSimpleType">
+		<annotation>
+			<documentation>iso15924 2016-07-14</documentation>
+		</annotation>
+		<restriction base="string">
+			<enumeration value="Adlm - Adlam"/>
+			<enumeration value="Afak - Afaka"/>
+			<enumeration value="Aghb - Caucasian Albanian"/>
+			<enumeration value="Ahom - Ahom, Tai Ahom"/>
+			<enumeration value="Arab - Arabic"/>
+			<enumeration value="Aran - Arabic (Nastaliq variant)"/>
+			<enumeration value="Armi - Imperial Aramaic"/>
+			<enumeration value="Armn - Armenian"/>
+			<enumeration value="Avst - Avestan"/>
+			<enumeration value="Bali - Balinese"/>
+			<enumeration value="Bamu - Bamum"/>
+			<enumeration value="Bass - Bassa Vah"/>
+			<enumeration value="Batk - Batak"/>
+			<enumeration value="Beng - Bengali"/>
+			<enumeration value="Bhks - Bhaiksuki"/>
+			<enumeration value="Blis - Blissymbols"/>
+			<enumeration value="Bopo - Bopomofo"/>
+			<enumeration value="Brah - Brahmi"/>
+			<enumeration value="Brai - Braille"/>
+			<enumeration value="Bugi - Buginese"/>
+			<enumeration value="Buhd - Buhid"/>
+			<enumeration value="Cakm - Chakma"/>
+			<enumeration value="Cans - Unified Canadian Aboriginal Syllabics"/>
+			<enumeration value="Cari - Carian"/>
+			<enumeration value="Cham - Cham"/>
+			<enumeration value="Cher - Cherokee"/>
+			<enumeration value="Cirt - Cirth"/>
+			<enumeration value="Copt - Coptic"/>
+			<enumeration value="Cprt - Cypriot"/>
+			<enumeration value="Cyrl - Cyrillic"/>
+			<enumeration value="Cyrs - Cyrillic (Old Church Slavonic variant)"/>
+			<enumeration value="Deva - Devanagari (Nagari)"/>
+			<enumeration value="Dsrt - Deseret (Mormon)"/>
+			<enumeration value="Dupl - Duployan shorthand, Duployan stenography"/>
+			<enumeration value="Egyd - Egyptian demotic"/>
+			<enumeration value="Egyh - Egyptian hieratic"/>
+			<enumeration value="Egyp - Egyptian hieroglyphs"/>
+			<enumeration value="Elba - Elbasan"/>
+			<enumeration value="Ethi - Ethiopic"/>
+			<enumeration value="Geok - Khutsuri (Asomtavruli and Nuskhuri)"/>
+			<enumeration value="Geor - Georgian (Mkhedruli)"/>
+			<enumeration value="Glag - Glagolitic"/>
+			<enumeration value="Goth - Gothic"/>
+			<enumeration value="Gran - Grantha"/>
+			<enumeration value="Grek - Greek"/>
+			<enumeration value="Gujr - Gujarati"/>
+			<enumeration value="Guru - Gurmukhi"/>
+			<enumeration value="Hanb - Han with Bopomofo"/>
+			<enumeration value="Hang - Hangul"/>
+			<enumeration value="Hani - Han (Hanzi, Kanji, Hanja)"/>
+			<enumeration value="Hano - Hanunoo (Hanunóo)"/>
+			<enumeration value="Hans - Han (Simplified variant)"/>
+			<enumeration value="Hant - Han (Traditional variant)"/>
+			<enumeration value="Hatr - Hatran"/>
+			<enumeration value="Hebr - Hebrew"/>
+			<enumeration value="Hira - Hiragana"/>
+			<enumeration value="Hluw - Anatolian Hieroglyphs"/>
+			<enumeration value="Hmng - Pahawh Hmong"/>
+			<enumeration value="Hrkt - Japanese syllabaries"/>
+			<enumeration value="Hung - Old Hungarian (Hungarian Runic)"/>
+			<enumeration value="Inds - Indus (Harappan)"/>
+			<enumeration value="Ital - Old Italic (Etruscan, Oscan etc.)"/>
+			<enumeration value="Jamo - Jamo"/>
+			<enumeration value="Java - Javanese"/>
+			<enumeration value="Jpan - Japanese"/>
+			<enumeration value="Jurc - Jurchen"/>
+			<enumeration value="Kali - Kayah Li"/>
+			<enumeration value="Kana - Katakana"/>
+			<enumeration value="Khar - Kharoshthi"/>
+			<enumeration value="Khmr - Khmer"/>
+			<enumeration value="Khoj - Khojki"/>
+			<enumeration value="Kitl - Khitan large script"/>
+			<enumeration value="Kits - Khitan small script"/>
+			<enumeration value="Knda - Kannada"/>
+			<enumeration value="Kore - Korean (alias for Hangul + Han)"/>
+			<enumeration value="Kpel - Kpelle"/>
+			<enumeration value="Kthi - Kaithi"/>
+			<enumeration value="Lana - Tai Tham (Lanna)"/>
+			<enumeration value="Laoo - Lao"/>
+			<enumeration value="Latf - Latin (Fraktur variant)"/>
+			<enumeration value="Latg - Latin (Gaelic variant)"/>
+			<enumeration value="Latn - Latin"/>
+			<enumeration value="Leke - Leke"/>
+			<enumeration value="Lepc - Lepcha (Róng)"/>
+			<enumeration value="Limb - Limbu"/>
+			<enumeration value="Lina - Linear A"/>
+			<enumeration value="Linb - Linear B"/>
+			<enumeration value="Lisu - Lisu (Fraser)"/>
+			<enumeration value="Loma - Loma"/>
+			<enumeration value="Lyci - Lycian"/>
+			<enumeration value="Lydi - Lydian"/>
+			<enumeration value="Mahj - Mahajani"/>
+			<enumeration value="Mand - Mandaic, Mandaean"/>
+			<enumeration value="Mani - Manichaean"/>
+			<enumeration value="Marc - Marchen"/>
+			<enumeration value="Maya - Mayan hieroglyphs"/>
+			<enumeration value="Mend - Mende Kikakui"/>
+			<enumeration value="Merc - Meroitic Cursive"/>
+			<enumeration value="Mero - Meroitic Hieroglyphs"/>
+			<enumeration value="Mlym - Malayalam"/>
+			<enumeration value="Modi - Modi, Moḍī"/>
+			<enumeration value="Mong - Mongolian"/>
+			<enumeration value="Moon - Moon (Moon code, Moon script, Moon type)"/>
+			<enumeration value="Mroo - Mro, Mru"/>
+			<enumeration value="Mtei - Meitei Mayek (Meithei, Meetei)"/>
+			<enumeration value="Mult - Multani"/>
+			<enumeration value="Mymr - Myanmar (Burmese)"/>
+			<enumeration value="Narb - Old North Arabian (Ancient North Arabian)"/>
+			<enumeration value="Nbat - Nabataean"/>
+			<enumeration value="Newa - Newa, Newar, Newari"/>
+			<enumeration value="Nkgb - Nakhi Geba"/>
+			<enumeration value="Nkoo - N’Ko"/>
+			<enumeration value="Nshu - Nüshu"/>
+			<enumeration value="Ogam - Ogham"/>
+			<enumeration value="Olck - Ol Chiki (Ol Cemet’, Ol, Santali)"/>
+			<enumeration value="Orkh - Old Turkic, Orkhon Runic"/>
+			<enumeration value="Orya - Oriya"/>
+			<enumeration value="Osge - Osage"/>
+			<enumeration value="Osma - Osmanya"/>
+			<enumeration value="Palm - Palmyrene"/>
+			<enumeration value="Pauc - Pau Cin Hau"/>
+			<enumeration value="Perm - Old Permic"/>
+			<enumeration value="Phag - Phags-pa"/>
+			<enumeration value="Phli - Inscriptional Pahlavi"/>
+			<enumeration value="Phlp - Psalter Pahlavi"/>
+			<enumeration value="Phlv - Book Pahlavi"/>
+			<enumeration value="Phnx - Phoenician"/>
+			<enumeration value="Piqd - Klingon (KLI pIqaD)"/>
+			<enumeration value="Plrd - Miao (Pollard)"/>
+			<enumeration value="Prti - Inscriptional Parthian"/>
+			<enumeration value="Rjng - Rejang (Redjang, Kaganga)"/>
+			<enumeration value="Roro - Rongorongo"/>
+			<enumeration value="Runr - Runic"/>
+			<enumeration value="Samr - Samaritan"/>
+			<enumeration value="Sara - Sarati"/>
+			<enumeration value="Sarb - Old South Arabian"/>
+			<enumeration value="Saur - Saurashtra"/>
+			<enumeration value="Sgnw - SignWriting"/>
+			<enumeration value="Shaw - Shavian (Shaw)"/>
+			<enumeration value="Shrd - Sharada, Śāradā"/>
+			<enumeration value="Sidd - Siddham"/>
+			<enumeration value="Sind - Khudawadi, Sindhi"/>
+			<enumeration value="Sinh - Sinhala"/>
+			<enumeration value="Sora - Sora Sompeng"/>
+			<enumeration value="Sund - Sundanese"/>
+			<enumeration value="Sylo - Syloti Nagri"/>
+			<enumeration value="Syrc - Syriac"/>
+			<enumeration value="Syre - Syriac (Estrangelo variant)"/>
+			<enumeration value="Syrj - Syriac (Western variant)"/>
+			<enumeration value="Syrn - Syriac (Eastern variant)"/>
+			<enumeration value="Tagb - Tagbanwa"/>
+			<enumeration value="Takr - Takri"/>
+			<enumeration value="Tale - Tai Le"/>
+			<enumeration value="Talu - New Tai Lue"/>
+			<enumeration value="Taml - Tamil"/>
+			<enumeration value="Tang - Tangut"/>
+			<enumeration value="Tavt - Tai Viet"/>
+			<enumeration value="Telu - Telugu"/>
+			<enumeration value="Teng - Tengwar"/>
+			<enumeration value="Tfng - Tifinagh (Berber)"/>
+			<enumeration value="Tglg - Tagalog (Baybayin, Alibata)"/>
+			<enumeration value="Thaa - Thaana"/>
+			<enumeration value="Thai - Thai"/>
+			<enumeration value="Tibt - Tibetan"/>
+			<enumeration value="Tirh - Tirhuta"/>
+			<enumeration value="Ugar - Ugaritic"/>
+			<enumeration value="Vaii - Vai"/>
+			<enumeration value="Visp - Visible Speech"/>
+			<enumeration value="Wara - Warang Citi (Varang Kshiti)"/>
+			<enumeration value="Wole - Woleai"/>
+			<enumeration value="Xpeo - Old Persian"/>
+			<enumeration value="Xsux - Cuneiform, Sumero-Akkadian"/>
+			<enumeration value="Yiii - Yi"/>
+			<enumeration value="Zinh - Code for inherited script"/>
+			<enumeration value="Zmth - Mathematical notation"/>
+			<enumeration value="Zsye - Symbols (Emoji variant)"/>
+			<enumeration value="Zsym - Symbols"/>
+			<enumeration value="Zxxx - Code for unwritten documents"/>
+			<enumeration value="Zyyy - Code for undetermined script"/>
+			<enumeration value="Zzzz - Code for uncoded script"/>
+			<enumeration value="other"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="ColourDepthSimpleType">
+		<restriction base="string">
+			<enumeration value="bilevel"/>
+			<enumeration value="greyscale"/>
+			<enumeration value="colour"/>
+			<enumeration value="other"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="GraphicsTypeSimpleType">
+		<restriction base="string">
+			<enumeration value="logo"/>
+			<enumeration value="letterhead"/>
+			<enumeration value="decoration"/>
+			<enumeration value="frame"/>
+			<enumeration value="handwritten-annotation"/>
+			<enumeration value="stamp"/>
+			<enumeration value="signature"/>
+			<enumeration value="barcode"/>
+			<enumeration value="paper-grow"/>
+			<enumeration value="punch-hole"/>
+			<enumeration value="other"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="ChartTypeSimpleType">
+		<restriction base="string">
+			<enumeration value="bar"/>
+			<enumeration value="line"/>
+			<enumeration value="pie"/>
+			<enumeration value="scatter"/>
+			<enumeration value="surface"/>
+			<enumeration value="other"/>
+		</restriction>
+	</simpleType>
+	<complexType name="LayersType">
+		<annotation>
+			<documentation>
+			Can be used to express the z-index of overlapping
+			regions. An element with a greater z-index is always in
+			front of another element with lower z-index.
+			</documentation>
+		</annotation>
+		<sequence minOccurs="1" maxOccurs="unbounded">
+			<element name="Layer" type="pc:LayerType"></element>
+		</sequence>
+	</complexType>
+
+	<complexType name="LayerType">
+		<sequence minOccurs="1" maxOccurs="unbounded">
+			<element name="RegionRef" type="pc:RegionRefType"/>
+		</sequence>
+		<attribute name="id" type="ID" use="required"/>
+		<attribute name="zIndex" type="int" use="required"/>
+		<attribute name="caption" type="string"/>
+	</complexType>
+
+	<complexType name="BaselineType">
+		<attribute name="points" type="pc:PointsType"
+			   use="required">
+		</attribute>
+		<attribute name="conf" type="pc:ConfSimpleType">
+			<annotation>
+				<documentation>Confidence value (between 0 and 1)</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+
+	<simpleType name="PointsType">
+		<annotation>
+			<documentation>
+			Point list with format "x1,y1 x2,y2 ...", where
+			"x" / "y" refer to the horizontal / vertical
+			pixel positions in a coordinate system which always
+			references the root PageType/@imageFilename, with
+			"0,0" in the upper left corner of the root image and
+			"imageWidth,imageHeight" in the lower right.</documentation>
+		</annotation>
+		<restriction base="string">
+			<pattern value="([0-9]+,[0-9]+ )+([0-9]+,[0-9]+)"></pattern>
+		</restriction>
+	</simpleType>
+
+	<complexType name="RelationsType">
+		<annotation>
+			<documentation>
+			Container for one-to-one relations between layout
+			objects (for example: DropCap - paragraph, caption -
+			image).
+			</documentation>
+		</annotation>
+		<sequence minOccurs="1" maxOccurs="unbounded">
+			<element name="Relation" type="pc:RelationType"/>
+		</sequence>
+	</complexType>
+
+	<complexType name="RelationType">
+		<annotation>
+			<documentation>
+			One-to-one relation between to layout object. Use 'link'
+			for loose relations and 'join' for strong relations
+			(where something is fragmented for instance).
+			
+			Examples for 'link': caption - image floating -
+			paragraph paragraph - paragraph (when a paragraph is
+			split across columns and the last word of the first
+			paragraph DOES NOT continue in the second paragraph)
+			drop-cap - paragraph (when the drop-cap is a whole word)
+			
+			Examples for 'join': word - word (separated word at the
+			end of a line) drop-cap - paragraph (when the drop-cap
+			is not a whole word) paragraph - paragraph (when a
+			pragraph is split across columns and the last word of
+			the first paragraph DOES continue in the second
+			paragraph)
+			</documentation>
+		</annotation>
+		<sequence>
+	    		<element name="Labels" type="pc:LabelsType"
+				 minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation>Semantic labels / tags</documentation>
+				</annotation>
+			</element>
+			<element name="SourceRegionRef" type="pc:RegionRefType"
+				 minOccurs="1" maxOccurs="1">
+			</element>
+			<element name="TargetRegionRef" type="pc:RegionRefType"
+				 minOccurs="1" maxOccurs="1">
+			</element>
+		</sequence>
+		<attribute name="id" type="ID" use="required"/>
+		<attribute name="type">
+			<simpleType>
+				<restriction base="string">
+					<enumeration value="link"/>
+					<enumeration value="join"/>
+				</restriction>
+			</simpleType>
+		</attribute>
+		<attribute name="custom" type="string">
+			<annotation>
+				<documentation>For generic use</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="comments" type="string"/>
+	</complexType>
+
+	<simpleType name="ProductionSimpleType">
+		<annotation>
+			<documentation>Text production type</documentation>
+		</annotation>
+		<restriction base="string">
+			<enumeration value="printed"/>
+			<enumeration value="typewritten"/>
+			<enumeration value="handwritten-cursive"/>
+			<enumeration value="handwritten-printscript"/>
+			<enumeration value="medieval-manuscript"/>
+			<enumeration value="other"/>
+		</restriction>
+	</simpleType>
+
+	<complexType name="TextStyleType">
+		<annotation>
+			<documentation>
+			Monospace (fixed-pitch, non-proportional) or
+			proportional font.
+			</documentation>
+		</annotation>
+		<attribute name="fontFamily" type="string">
+			<annotation>
+				<documentation>
+				For instance: Arial, Times New Roman.
+				Add more information if necessary
+				(e.g. blackletter, antiqua).
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="serif" type="boolean">
+			<annotation>
+				<documentation>
+				Serif or sans-serif typeface.
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="monospace" type="boolean"/>
+		<attribute name="fontSize" type="float">
+			<annotation>
+				<documentation>
+				The size of the characters in points.
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="xHeight" type="integer">
+			<annotation>
+				<documentation>
+				The x-height or corpus size refers to the distance
+				between the baseline and the mean line of
+				lower-case letters in a typeface.
+				The unit is assumed to be pixels.
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="kerning" type="int">
+			<annotation>
+				<documentation>
+				The degree of space (in points) between
+				the characters in a string of text.
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="textColour" type="pc:ColourSimpleType"/>
+		<attribute name="textColourRgb" type="integer">
+			<annotation>
+				<documentation>
+				Text colour in RGB encoded format
+				(red value) + (256 x green value) + (65536 x blue value).
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="bgColour" type="pc:ColourSimpleType">
+			<annotation>
+				<documentation>Background colour</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="bgColourRgb" type="integer">
+			<annotation>
+				<documentation>
+				Background colour in RGB encoded format
+				(red value) + (256 x green value) + (65536 x blue value).
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="reverseVideo" type="boolean">
+			<annotation>
+				<documentation>
+				Specifies whether the colour of the text appears
+				reversed against a background colour.
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="bold" type="boolean"/>
+		<attribute name="italic" type="boolean"/>
+		<attribute name="underlined" type="boolean"/>
+		<attribute name="underlineStyle"
+			type="pc:UnderlineStyleSimpleType" use="optional">
+			<annotation>
+				<documentation>Line style details if "underlined" is TRUE
+				</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="subscript" type="boolean"/>
+		<attribute name="superscript" type="boolean"/>
+		<attribute name="strikethrough" type="boolean"/>
+		<attribute name="smallCaps" type="boolean"/>
+		<attribute name="letterSpaced" type="boolean"/>
+	</complexType>
+
+	<complexType name="RegionType" abstract="true">
+		<sequence>
+			<element name="AlternativeImage" type="pc:AlternativeImageType"
+				 minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation>
+					Alternative region images
+					(e.g. black-and-white).
+					</documentation>
+				</annotation>
+			</element>
+			<element name="Coords" type="pc:CoordsType"/>
+			<element name="UserDefined" type="pc:UserDefinedType"
+				 minOccurs="0" maxOccurs="1">
+			</element>
+			<element name="Labels" type="pc:LabelsType"
+				 minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation>Semantic labels / tags</documentation>
+				</annotation>
+			</element>    		
+			<element name="Roles" type="pc:RolesType"
+				 minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					Roles the region takes
+					(e.g. in context of a parent region).
+					</documentation>
+				</annotation>
+			</element>
+			<choice minOccurs="0" maxOccurs="unbounded">
+				<element name="TextRegion" type="pc:TextRegionType"/>
+				<element name="ImageRegion" type="pc:ImageRegionType"/>
+				<element name="LineDrawingRegion" type="pc:LineDrawingRegionType"/>
+				<element name="GraphicRegion" type="pc:GraphicRegionType"/>
+				<element name="TableRegion" type="pc:TableRegionType"/>
+				<element name="ChartRegion" type="pc:ChartRegionType"/>
+				<element name="SeparatorRegion" type="pc:SeparatorRegionType"/>
+				<element name="MathsRegion" type="pc:MathsRegionType"/>
+				<element name="ChemRegion" type="pc:ChemRegionType"/>
+				<element name="MusicRegion" type="pc:MusicRegionType"/>
+				<element name="AdvertRegion" type="pc:AdvertRegionType"/>
+				<element name="NoiseRegion" type="pc:NoiseRegionType"/>
+				<element name="UnknownRegion" type="pc:UnknownRegionType"/>
+				<element name="CustomRegion" type="pc:CustomRegionType"/>
+			</choice>
+		</sequence>
+		<attribute name="id" type="ID" use="required"/>
+		<attribute name="custom" type="string">
+			<annotation>
+				<documentation>For generic use</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="comments" type="string"/>
+		<attribute name="continuation" type="boolean">
+			<annotation>
+				<documentation>
+				Is this region a continuation of another region
+				(in previous column or page, for example)?
+				</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+
+	<complexType name="AlternativeImageType">
+		<attribute name="filename" type="string" use="required"/>
+		<attribute name="comments" type="string"/>
+		<attribute name="conf" type="pc:ConfSimpleType">
+			<annotation>
+				<documentation>Confidence value (between 0 and 1)</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+
+	<simpleType name="AlignSimpleType">
+		<restriction base="string">
+			<enumeration value="left"/>
+			<enumeration value="centre"/>
+			<enumeration value="right"/>
+			<enumeration value="justify"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="GroupTypeSimpleType">
+		<restriction base="string">
+			<enumeration value="paragraph"/>
+			<enumeration value="list"/>
+			<enumeration value="list-item"/>
+			<enumeration value="figure"/>
+			<enumeration value="article"/>
+			<enumeration value="div"/>
+			<enumeration value="other"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="TextDataTypeSimpleType">
+		<restriction base="string">
+			<enumeration value="xsd:decimal">
+				<annotation>
+					<documentation>
+					Examples:
+					"123.456", "+1234.456",
+					"-1234.456", "-.456", "-456"
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="xsd:float">
+				<annotation>
+					<documentation>
+					Examples:
+					"123.456", "+1234.456", "-1.2344e56",
+					"-.45E-6", "INF", "-INF", "NaN"
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="xsd:integer">
+				<annotation>
+					<documentation>
+					Examples:
+					"123456", "+00000012", "-1", "-456"
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="xsd:boolean">
+				<annotation>
+					<documentation>
+					Examples: "true", "false", "1", "0"
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="xsd:date">
+				<annotation>
+					<documentation>
+					Examples:
+					"2001-10-26", "2001-10-26+02:00",
+					"2001-10-26Z", "2001-10-26+00:00",
+					"-2001-10-26", "-20000-04-01"
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="xsd:time">
+				<annotation>
+					<documentation>
+					Examples:
+					"21:32:52", "21:32:52+02:00", "19:32:52Z",
+					"19:32:52+00:00", "21:32:52.12679"
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="xsd:dateTime">
+				<annotation>
+					<documentation>
+					Examples:
+					"2001-10-26T21:32:52", "2001-10-26T21:32:52+02:00",
+					"2001-10-26T19:32:52Z", "2001-10-26T19:32:52+00:00",
+					"-2001-10-26T21:32:52", "2001-10-26T21:32:52.12679"
+					</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="xsd:string">
+				<annotation>
+					<documentation>Generic text string</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="other">
+				<annotation>
+					<documentation>
+					An XSD type that is not listed or a custom type
+					(use dataTypeDetails attribute).
+					</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<complexType name="GraphemesType">
+		<annotation>
+			<documentation>
+			Container for graphemes, grapheme groups and
+			non-printing characters.
+			</documentation>
+		</annotation>
+		<choice minOccurs="1" maxOccurs="unbounded">
+			<element name="Grapheme" type="pc:GraphemeType"/>
+			<element name="NonPrintingChar" type="pc:NonPrintingCharType"/>
+			<element name="GraphemeGroup" type="pc:GraphemeGroupType"/>
+		</choice>
+	</complexType>
+	<complexType name="GraphemeBaseType" abstract="true">
+		<annotation>
+			<documentation>
+			Base type for graphemes, grapheme groups and non-printing characters.
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="TextEquiv" type="pc:TextEquivType"
+				 minOccurs="0" maxOccurs="unbounded"/>
+		</sequence>
+		<attribute name="id" type="ID" use="required"/>
+		<attribute name="index" use="required">
+			<annotation>
+				<documentation>
+				Order index of grapheme, group, or non-printing character
+				within the parent container (graphemes or glyph or grapheme group).
+				</documentation>
+			</annotation>
+			<simpleType>
+				<restriction base="int">
+					<minInclusive value="0"></minInclusive>
+				</restriction>
+			</simpleType>
+		</attribute>
+		<attribute name="ligature" type="boolean"/>
+		<attribute name="charType">
+			<annotation>
+				<documentation>
+				Type of character represented by the
+				grapheme, group, or non-printing character element.
+				</documentation>
+			</annotation>
+			<simpleType>
+				<restriction base="string">
+					<enumeration value="base"/>
+					<enumeration value="combining"/>
+				</restriction>
+			</simpleType>
+		</attribute>
+		<attribute name="custom" type="string">
+			<annotation>
+				<documentation>For generic use</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="comments" type="string">
+			<annotation>
+				<documentation>For generic use</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<complexType name="GraphemeType">
+		<annotation>
+			<documentation>
+			Represents a sub-element of a glyph.
+			Smallest graphical unit that can be
+			assigned a Unicode code point.
+			</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="pc:GraphemeBaseType">
+				<sequence>
+					<element name="Coords" type="pc:CoordsType"/>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="NonPrintingCharType">
+		<annotation>
+			<documentation>
+			  A glyph component without visual representation
+			  but with Unicode code point.
+			  Non-visual / non-printing / control character.
+			  Part of grapheme container (of glyph) or grapheme sub group.
+			</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="pc:GraphemeBaseType">
+			</extension>
+		</complexContent>
+	</complexType>
+	<complexType name="GraphemeGroupType">
+		<complexContent>
+			<extension base="pc:GraphemeBaseType">
+				<choice minOccurs="0" maxOccurs="unbounded">
+					<element name="Grapheme" type="pc:GraphemeType"/>
+					<element name="NonPrintingChar" type="pc:NonPrintingCharType"/>
+				</choice>
+			</extension>
+		</complexContent>
+	</complexType>
+
+	<complexType name="UserDefinedType">
+		<annotation>
+			<documentation>Container for user-defined attributes</documentation>
+		</annotation>
+		<sequence>
+			<element name="UserAttribute" type="pc:UserAttributeType"
+				 minOccurs="1" maxOccurs="unbounded">
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="UserAttributeType">
+		<annotation>
+			<documentation>Structured custom data defined by name, type and value.</documentation>
+		</annotation>
+		<attribute name="name" type="string"/>
+		<attribute name="description" type="string"/>
+		<attribute name="type">
+			<simpleType>
+				<restriction base="string">
+					<enumeration value="xsd:string"/>
+					<enumeration value="xsd:integer"/>
+					<enumeration value="xsd:boolean"/>
+					<enumeration value="xsd:float"/>
+				</restriction>
+			</simpleType>
+		</attribute>
+		<attribute name="value" type="string"/>
+	</complexType>
+
+	<complexType name="TableCellRoleType">
+		<attribute name="rowIndex" type="int" use="required">
+			<annotation>
+				<documentation>Cell position in table starting with row 0</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="columnIndex" type="int" use="required">
+			<annotation>
+				<documentation>Cell position in table starting with column 0</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="rowSpan" type="int">
+			<annotation>
+				<documentation>Number of rows the cell spans (optional; default is 1)</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="colSpan" type="int">
+			<annotation>
+				<documentation>Number of columns the cell spans (optional; default is 1)</documentation>
+			</annotation>
+		</attribute>
+		<attribute name="header" type="boolean">
+			<annotation>
+				<documentation>
+				Is the cell a column or row header?
+				</documentation>
+			</annotation>
+		</attribute>    	
+	</complexType>
+	<complexType name="RolesType">
+		<sequence>
+			<element name="TableCellRole" type="pc:TableCellRoleType"
+				 minOccurs="0" maxOccurs="1">
+				<annotation>
+					<documentation>
+					Data for a region that takes on the role
+					of a table cell within a parent table region.
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<simpleType name="UnderlineStyleSimpleType">
+		<restriction base="string">
+			<enumeration value="singleLine" />
+			<enumeration value="doubleLine" />
+			<enumeration value="other" />
+		</restriction>
+	</simpleType>
+</schema>


### PR DESCRIPTION
This is a replacement for #10 which got closed due to rewriting the Git history:

```
CLI: delegate to click.File
CLI: default to all fixers
TableCell: convert @Label, too
TableCell/Region: preserve all std attributes and elements
add option for validation of output
fix TextEquiv/UnicodeAlternative
delegate to TranskribusFixer class for choices available, add docstrings
add fixer for Page/@image* transformation attributes
add fixer removing Tag, Property and Link elements
add option to promote TranskribusMetadata/@imgurl to @imageFilename
```

@bertsky LGTM but please check I didn't mess anything up when redoing the PR.